### PR TITLE
Adding support for .NET Standard 

### DIFF
--- a/Frameworks/MQTTnet.Netstandard/MQTTnet.Netstandard.csproj
+++ b/Frameworks/MQTTnet.Netstandard/MQTTnet.Netstandard.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <AssemblyName>MQTTnet</AssemblyName>
+    <RootNamespace>MQTTnet</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Frameworks/MQTTnet.Netstandard/MQTTnet.Netstandard.csproj
+++ b/Frameworks/MQTTnet.Netstandard/MQTTnet.Netstandard.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MQTTnet.NetCoreApp\Implementations\MqttServerAdapter.cs" Link="Implementations\MqttServerAdapter.cs" />
+    <Compile Include="..\MQTTnet.NetCoreApp\Implementations\MqttTcpChannel.cs" Link="Implementations\MqttTcpChannel.cs" />
+    <Compile Include="..\MQTTnet.NetCoreApp\MqttClientFactory.cs" Link="MqttClientFactory.cs" />
+    <Compile Include="..\MQTTnet.NetCoreApp\MqttServerFactory.cs" Link="MqttServerFactory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MQTTnet.Core\MQTTnet.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Implementations\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/MQTTnet.nuspec
+++ b/MQTTnet.nuspec
@@ -15,9 +15,17 @@
 * [Server] Added TLS 1.2 support (but not for UWP) (thanks to Zazzmatazz)
 * [Client] Added TLS 1.2 support (thanks to Zazzmatazz)
 * [Core] Optimized async task management
-* [Nuget] Fixed x64 files</releaseNotes>
+* [Nuget] Fixed x64 files
+* [.NET Standard] Added support for .NET Standard 1.3</releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2017</copyright>
-    <tags>MQTT MQTTClient MQTTServer MQTTBroker Broker</tags>
+    <tags>MQTT MQTTClient MQTTServer MQTTBroker Broker</tags> 
+    <dependencies>
+
+      <group targetFramework="netstandard1.3">
+        <dependency id="System.Net.Security" version="4.3.1" />
+      </group>
+
+    </dependencies>
   </metadata>
 
   <files>
@@ -51,6 +59,10 @@
     <!-- .NET Core App -->
     <file src=".\Frameworks\MQTTnet.NetCoreApp\bin\Release\netcoreapp1.1\MQTTnet.Core.dll" target="lib\netcoreapp1.1"/>
     <file src=".\Frameworks\MQTTnet.NetCoreApp\bin\Release\netcoreapp1.1\MQTTnet.dll" target="lib\netcoreapp1.1"/>
+
+    <!-- .NET Standard 1.3 -->
+    <file src=".\Frameworks\MQTTnet.Netstandard\bin\Release\netstandard1.3\MQTTnet.Core.dll" target="lib\netstandard1.3"/>
+    <file src=".\Frameworks\MQTTnet.Netstandard\bin\Release\netstandard1.3\MQTTnet.dll" target="lib\netstandard1.3"/>
     
   </files>
 </package>

--- a/MQTTnet.sln
+++ b/MQTTnet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.12
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MQTTnet.Core.Tests", "Tests\MQTTnet.Core.Tests\MQTTnet.Core.Tests.csproj", "{A7FF0C91-25DE-4BA6-B39E-F54E8DADF1CC}"
 EndProject
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{9248C2E1
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Frameworks", "Frameworks", "{32A630A7-2598-41D7-B625-204CD906F5FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MQTTnet.Core", "MQTTnet.Core\MQTTnet.Core.csproj", "{2ECB99E4-72D0-4C23-99BA-93D511D3967D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MQTTnet.Core", "MQTTnet.Core\MQTTnet.Core.csproj", "{2ECB99E4-72D0-4C23-99BA-93D511D3967D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{002203AF-2565-4C0D-95ED-027FDEFE0C35}"
 	ProjectSection(SolutionItems) = preProject
@@ -25,6 +25,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MQTTnet.TestApp.NetFramework", "Tests\MQTTnet.TestApp.NetFramework\MQTTnet.TestApp.NetFramework.csproj", "{D9D74F33-6943-49B2-B765-7BD589082098}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MQTTnet.TestApp.UniversalWindows", "Tests\MQTTnet.TestApp.UniversalWindows\MQTTnet.TestApp.UniversalWindows.csproj", "{FF1F72D6-9524-4422-9497-3CC0002216ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MQTTnet.Netstandard", "Frameworks\MQTTnet.Netstandard\MQTTnet.Netstandard.csproj", "{3587E506-55A2-4EB3-99C7-DC01E42D25D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -152,6 +154,22 @@ Global
 		{FF1F72D6-9524-4422-9497-3CC0002216ED}.Release|x86.ActiveCfg = Release|x86
 		{FF1F72D6-9524-4422-9497-3CC0002216ED}.Release|x86.Build.0 = Release|x86
 		{FF1F72D6-9524-4422-9497-3CC0002216ED}.Release|x86.Deploy.0 = Release|x86
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Debug|x86.Build.0 = Debug|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|ARM.Build.0 = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|x64.Build.0 = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,5 +181,6 @@ Global
 		{1A1B7F51-5328-4395-9D9C-07D70965825E} = {32A630A7-2598-41D7-B625-204CD906F5FB}
 		{D9D74F33-6943-49B2-B765-7BD589082098} = {9248C2E1-B9D6-40BF-81EC-86004D7765B4}
 		{FF1F72D6-9524-4422-9497-3CC0002216ED} = {9248C2E1-B9D6-40BF-81EC-86004D7765B4}
+		{3587E506-55A2-4EB3-99C7-DC01E42D25D2} = {32A630A7-2598-41D7-B625-204CD906F5FB}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MQTTnet is a .NET library for MQTT based communication. It provides a MQTT clien
 * Lightweight (only the low level implementation of MQTT, no overhead)
 
 ## Supported frameworks
-* .NET Standard 1.1+
+* .NET Standard 1.3+
 * .NET Core 1.1+
 * .NET Core App 1.1+
 * .NET Framework 4.5.2+ (x86, x64, AnyCPU)
@@ -45,7 +45,7 @@ If you use this library and want to see your project here please let me know.
 # MqttClient
 ## Example
 
-```c#
+```csharp
 var options = new MqttClientOptions
 {
     Server = "localhost"
@@ -119,7 +119,7 @@ while (true)
 
 ## Example 
 
-```c#
+```csharp
 var options = new MqttServerOptions
 {
     ConnectionValidator = p =>


### PR DESCRIPTION
Your current library does not support .NET Standard. As in: You cannot reference the libreary from another .NET Standard project. You can only reference it from a .NET Core project.

This pull request adds this support of .NET Standard.

No code have been changed. I've added a project that links to you existing .NET Core project code and I've changed the nuspec file so that it should now create a .NET Standard library. To do this I had to reference System.Net.Security 4.3.1. This is also added to the nuspec file, but only for .NET Standard

Also, I could not go any lower that .NET Standard 1.3.

Hope you will find this helpful and will release a new Nuget version with .NET Standard 1.3 support. Let me know if it gives you any trouble.

Thank you for writing this library!