### PR TITLE
Bug fixes

### DIFF
--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -24,7 +24,7 @@
 
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="System.Net.Security" version="4.3.1" />
+        <dependency id="System.Net.Security" version="4.3.2" />
       </group>
       
       <group targetFramework="uap10.0">

--- a/Frameworks/MQTTnet.NetStandard/MQTTnet.Netstandard.csproj
+++ b/Frameworks/MQTTnet.NetStandard/MQTTnet.Netstandard.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />

--- a/Frameworks/MQTTnet.UniversalWindows/MQTTnet.UniversalWindows.csproj
+++ b/Frameworks/MQTTnet.UniversalWindows/MQTTnet.UniversalWindows.csproj
@@ -130,11 +130,6 @@
       <Version>5.4.0</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Net.Security">
-      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.0.0\ref\netcoreapp2.0\System.Net.Security.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/MQTTnet.Core/Adapter/MqttChannelCommunicationAdapter.cs
+++ b/MQTTnet.Core/Adapter/MqttChannelCommunicationAdapter.cs
@@ -83,35 +83,39 @@ namespace MQTTnet.Core.Adapter
                 {
                     foreach (var packet in packets)
                     {
-                        MqttTrace.Information(nameof(MqttChannelCommunicationAdapter), "TX >>> {0} [Timeout={1}]", packet, timeout);
+                        if (packet == null) continue;
+
+                        MqttTrace.Information(nameof(MqttChannelCommunicationAdapter), $"TX >>> {packet} [Timeout={timeout}]");
 
                         var writeBuffer = PacketSerializer.Serialize(packet);
                         _sendTask = _sendTask.ContinueWith(p => _channel.SendStream.WriteAsync(writeBuffer, 0, writeBuffer.Length, cancellationToken).ConfigureAwait(false), cancellationToken);
                     }
+
+                    if (timeout > TimeSpan.Zero)
+                    {
+                        _sendTask = _sendTask.ContinueWith(c => _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout), cancellationToken);// _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout);//.ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _sendTask = _sendTask.ContinueWith(c => _channel.SendStream.FlushAsync(cancellationToken), cancellationToken);
+                    }
+
                 }
 
                 await _sendTask; // configure await false generates stackoverflow
 
-                if (timeout > TimeSpan.Zero)
-                {
-                    await _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
-                }
-                else
-                {
-                    await _channel.SendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
-                }
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException ex)
             {
-                throw;
+                throw ex;
             }
-            catch (MqttCommunicationTimedOutException)
+            catch (MqttCommunicationTimedOutException ex)
             {
-                throw;
+                throw ex;
             }
-            catch (MqttCommunicationException)
+            catch (MqttCommunicationException ex)
             {
-                throw;
+                throw ex;
             }
             catch (Exception exception)
             {

--- a/MQTTnet.Core/Adapter/MqttChannelCommunicationAdapter.cs
+++ b/MQTTnet.Core/Adapter/MqttChannelCommunicationAdapter.cs
@@ -83,7 +83,7 @@ namespace MQTTnet.Core.Adapter
                 {
                     foreach (var packet in packets)
                     {
-                        if (packet == null) continue;
+                        if (packet == null) {continue};
 
                         MqttTrace.Information(nameof(MqttChannelCommunicationAdapter), $"TX >>> {packet} [Timeout={timeout}]");
 
@@ -93,7 +93,7 @@ namespace MQTTnet.Core.Adapter
 
                     if (timeout > TimeSpan.Zero)
                     {
-                        _sendTask = _sendTask.ContinueWith(c => _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout), cancellationToken);// _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout);//.ConfigureAwait(false);
+                        _sendTask = _sendTask.ContinueWith(c => _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout), cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -105,17 +105,17 @@ namespace MQTTnet.Core.Adapter
                 await _sendTask; // configure await false generates stackoverflow
 
             }
-            catch (TaskCanceledException ex)
+            catch (TaskCanceledException)
             {
-                throw ex;
+                throw;
             }
-            catch (MqttCommunicationTimedOutException ex)
+            catch (MqttCommunicationTimedOutException)
             {
-                throw ex;
+                throw;
             }
-            catch (MqttCommunicationException ex)
+            catch (MqttCommunicationException)
             {
-                throw ex;
+                throw;
             }
             catch (Exception exception)
             {

--- a/MQTTnet.Core/Client/MqttClient.cs
+++ b/MQTTnet.Core/Client/MqttClient.cs
@@ -63,6 +63,7 @@ namespace MQTTnet.Core.Client
                 };
 
                 var response = await SendAndReceiveAsync<MqttConnAckPacket>(connectPacket).ConfigureAwait(false);
+                
                 if (response.ConnectReturnCode != MqttConnectReturnCode.ConnectionAccepted)
                 {
                     throw new MqttConnectingFailedException(response.ConnectReturnCode);


### PR DESCRIPTION
I fixed a few bugs.

On `MQTTnet.UniversalWindows.csproj` : it's best with no refererence to System.Net.Security as it's not compatible with UWP (see [here](https://github.com/dotnet/corefx/issues/19783))

On `MqttChannelCommunicationAdapter.cs `. You lock on _channel to compose a Task. But shouldn't the FlushAsync be part of this Task?

Also, I updated .NET Standard 1.3 to use the latest version of System.Net.Security.