### PR TITLE
Fix for ignored certificate information

### DIFF
--- a/MQTTnet.Core/Client/MqttClientOptionsBuilder.cs
+++ b/MQTTnet.Core/Client/MqttClientOptionsBuilder.cs
@@ -119,11 +119,11 @@ namespace MQTTnet.Core.Client
 
                 if (_tcpOptions != null)
                 {
-                    _options.ChannelOptions = _tcpOptions;
+                    _tcpOptions.TlsOptions = _tlsOptions;
                 }
                 else
                 {
-                    _options.ChannelOptions = _webSocketOptions;
+                    _webSocketOptions.TlsOptions = _tlsOptions;
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ MQTTnet is a high performance .NET library for MQTT based communication. It prov
 * .NET Standard 1.3+
 * .NET Core 1.1+
 * .NET Core App 1.1+
-* Universal Windows Platform (UWP) 10.0.10240+ (x86, x64, ARM, AnyCPU, WIndows IoT Core)
+* Universal Windows Platform (UWP) 10.0.10240+ (x86, x64, ARM, AnyCPU, Windows 10 IoT Core)
 * .NET Framework 4.5.2+ (x86, x64, AnyCPU)
 * Mono 5.2+
 * Xamarin.Android 7.5+


### PR DESCRIPTION
_tlsOptions was never assigned when building an instance of MqttClientOptions using an MQttClientOptionsBuilder, and certificate information was being lost.

This was a part of the cause of issue #115.