### PR TITLE
Serialized certificates loaded as X509Certificate2

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpChannel.cs
+++ b/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpChannel.cs
@@ -130,7 +130,7 @@ namespace MQTTnet.Implementations
 
             foreach (var certificate in options.TlsOptions.Certificates)
             {
-                certificates.Add(new X509Certificate(certificate));
+                certificates.Add(new X509Certificate2(certificate));
             }
 
             return certificates;

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ MQTTnet is a high performance .NET library for MQTT based communication. It prov
 * .NET Standard 1.3+
 * .NET Core 1.1+
 * .NET Core App 1.1+
-* Universal Windows Platform (UWP) 10.0.10240+ (x86, x64, ARM, AnyCPU, WIndows IoT Core)
+* Universal Windows Platform (UWP) 10.0.10240+ (x86, x64, ARM, AnyCPU, Windows 10 IoT Core)
 * .NET Framework 4.5.2+ (x86, x64, AnyCPU)
 * Mono 5.2+
 * Xamarin.Android 7.5+


### PR DESCRIPTION
Instances of X509Certificate2 passed into an MqttClientOptionsBuilder lose data and functionality by being loaded as an X509Certificate, most notably the private key which servers may require for client validation.

To the best of my knowledge, instances of X509Certificate do not lose data or functionality by being loaded as an X509Certificate2.