### PR TITLE
Fix infinite loop when the client closes the connection

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
@@ -137,6 +137,12 @@ namespace MQTTnet.Adapter
             do
             {
                 var readBytesCount = await stream.ReadAsync(body, offset, body.Length - offset, cancellationToken).ConfigureAwait(false);
+                // Check if the client closed the connection before sending the full body.
+                if (readBytesCount == 0)
+                {
+                    throw new MqttCommunicationException("Connection closed while reading remaining packet body.");
+                }
+
                 offset += readBytesCount;
             } while (offset < header.BodyLength);
             


### PR DESCRIPTION
Hi,

when reviewing the code in `MqttChannelAdapter.ReceiveAsync()`, I found that it can enter an infinite loop when the client closes the connection before sending the full packet body, because it does not handle the case when `await Stream.ReadAsync()` returns 0.

To reproduce, you can start the TestApp and start the server, and then using a program like this to connect to the server:
```c#
        static void Main(string[] args)
        {
            using (var client = new TcpClient("127.0.0.1", 1883)) {
                using (var stream = client.GetStream()) {
                    var buffer = new byte[] { 0x10, 0x10, 0x00 };
                    stream.Write(buffer, 0, buffer.Length);
                }
            }
        }
```

When you start this program, one of the worker threads from the server will get into an infinite loop until a TimeoutException occurs. To fix the issue, I added a check for a return value of `0` and throw an exception in this case, similar to the code in `MqttPacketReader.ReadBodyLengthFromSourceAsync()`.

Thanks!