### PR TITLE
Fix the algorithm for decoding the body length

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketReader.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketReader.cs
@@ -86,7 +86,7 @@ namespace MQTTnet.Serializer
 
         private static async Task<int> ReadBodyLengthFromSourceAsync(Stream stream, CancellationToken cancellationToken)
         {
-            // Alorithm taken from http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html.
+            // Alorithm taken from https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html.
             var multiplier = 1;
             var value = 0;
             byte encodedByte;
@@ -110,11 +110,11 @@ namespace MQTTnet.Serializer
                 readBytes.Add(encodedByte);
 
                 value += (byte)(encodedByte & 127) * multiplier;
-                multiplier *= 128;
                 if (multiplier > 128 * 128 * 128)
                 {
                     throw new MqttProtocolViolationException($"Remaining length is invalid (Data={string.Join(",", readBytes)}).");
                 }
+                multiplier *= 128;
             } while ((encodedByte & 128) != 0);
 
             return value;


### PR DESCRIPTION
Hi,

the algorithm in `MqttPacketReader.ReadBodyLengthFromSourceAsync()` to decode the remaining length only allows up to 2,097,151 bytes, whereas the MQTT 3.1.1 specification says:

>This allows applications to send Control Packets of size up to 268,435,455 (256 MB). The representation of this number on the wire is: 0xFF, 0xFF, 0xFF, 0x7F. 

This is because there was an error in the pseudocode that has been fixed in the [latest version of the specification](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180836). See [MQTT Version 3.1.1 Errata 01 2.1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os.html#_Toc442180732).

However, I think it would also be a good idea to allow the user to limit thee maximum packet size that will be processed, to avoid a DoS surface. For example, a client could open a few TCP connections and send the bytes `0x10, 0xFF, 0xFF, 0xFF, 0x7F` on each connection. This would cause the server to allocate a 256 MB memory block for each connection, even if the client did not yet send a part of the variable header or the payload. Thus, a client could make the server exhaust all of its memory with just sending a few bytes.

Additionally, the code `var body = new byte[header.BodyLength];` could be changed to create a `MemoryStream` that initially has a small byte array, but increases the array while receiving data from the client, which would mean the server allocates only about as much memory as the client already sent (although this would require a bit more work as the array would be resized a few times). What do you think?

Thanks!