### PR TITLE
Optimize receiving the packet body

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Adapter/ReceivedMqttPacket.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/ReceivedMqttPacket.cs
@@ -1,24 +1,18 @@
 ﻿using System;
-using System.IO;
 using MQTTnet.Packets;
 
 namespace MQTTnet.Adapter
 {
-    public sealed class ReceivedMqttPacket : IDisposable
+    public class ReceivedMqttPacket
     {
-        public ReceivedMqttPacket(MqttPacketHeader header, MemoryStream body)
+        public ReceivedMqttPacket(MqttPacketHeader header, ArraySegment<byte> body)
         {
             Header = header ?? throw new ArgumentNullException(nameof(header));
-            Body = body ?? throw new ArgumentNullException(nameof(body));
+            Body = body;
         }
 
         public MqttPacketHeader Header { get; }
 
-        public MemoryStream Body { get; }
-
-        public void Dispose()
-        {
-            Body?.Dispose();
-        }
+        public ArraySegment<byte> Body { get; }
     }
 }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/IMqttPacketSerializer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/IMqttPacketSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using MQTTnet.Packets;
 
 namespace MQTTnet.Serializer
@@ -11,6 +10,6 @@ namespace MQTTnet.Serializer
 
         ICollection<ArraySegment<byte>> Serialize(MqttBasePacket mqttPacket);
 
-        MqttBasePacket Deserialize(MqttPacketHeader header, MemoryStream body);
+        MqttBasePacket Deserialize(MqttPacketHeader header, ArraySegment<byte> body);
     }
 }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketSerializer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketSerializer.cs
@@ -45,6 +45,7 @@ namespace MQTTnet.Serializer
         public MqttBasePacket Deserialize(MqttPacketHeader header, ArraySegment<byte> body)
         {
             if (header == null) throw new ArgumentNullException(nameof(header));
+            if (body.Array == null) throw new ArgumentException($"{nameof(body)}.{nameof(body.Array)} must not be null");
 
             using (var bodyStream = new MemoryStream(body.Array, body.Offset, body.Count))
             using (var reader = new MqttPacketReader(header, bodyStream))

--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketSerializer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketSerializer.cs
@@ -42,12 +42,12 @@ namespace MQTTnet.Serializer
             }
         }
 
-        public MqttBasePacket Deserialize(MqttPacketHeader header, MemoryStream body)
+        public MqttBasePacket Deserialize(MqttPacketHeader header, ArraySegment<byte> body)
         {
             if (header == null) throw new ArgumentNullException(nameof(header));
-            if (body == null) throw new ArgumentNullException(nameof(body));
 
-            using (var reader = new MqttPacketReader(header, body))
+            using (var bodyStream = new MemoryStream(body.Array, body.Offset, body.Count))
+            using (var reader = new MqttPacketReader(header, bodyStream))
             {
                 return Deserialize(header, reader);
             }

--- a/Tests/MQTTnet.Core.Tests/MqttPacketSerializerTests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttPacketSerializerTests.cs
@@ -409,7 +409,7 @@ namespace MQTTnet.Core.Tests
 
                 using (var bodyStream = new MemoryStream(Join(buffer1), (int)headerStream.Position, header.BodyLength))
                 {
-                    var deserializedPacket = serializer.Deserialize(header, bodyStream);
+                    var deserializedPacket = serializer.Deserialize(header, new ArraySegment<byte>(bodyStream.ToArray()));
                     var buffer2 = serializer.Serialize(deserializedPacket);
 
                     Assert.AreEqual(expectedBase64Value, Convert.ToBase64String(Join(buffer2)));


### PR DESCRIPTION
Hi Christian,

I saw that you created commit 1415e4b878488a62741bb9be98e39a36365b6141 as follow-up to #166. Thank you!

However, I noticed there were some problems in the new code:
- When calling `new MemoryStream(byte[])`, its `Length` property is set to the size of the array, so the code would probably need to call `.SetLength(0)` to reset the length.
- The code for receiving into the buffer always used `buffer.Length` as count even if `header.BodyLength - body.Length < buffer.Length`, which meant it would receive too many bytes for a packet.

I think it can be optimized to only create a MemoryStream if the body length is actually greater than the read buffer length, and I think that `ReceivedMqttPacket` does not need to hold the `MemoryStream`, but instead could hold the MemoryStream's buffer as `ArraySegment<byte>`, so it does not need to be disposable, as shown in the PR.

What do you think?

Thanks!

