### PR TITLE
Optmizations

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -55,52 +56,41 @@ namespace MQTTnet.Adapter
 
             return ExecuteAndWrapExceptionAsync(async () =>
             {
-                await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
+                foreach (var packet in packets)
                 {
-                    foreach (var packet in packets)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            return;
-                        }
-
-                        if (packet == null)
-                        {
-                            continue;
-                        }
-
-                        _logger.Verbose<MqttChannelAdapter>("TX >>> {0} [Timeout={1}]", packet, timeout);
-
-                        var chunks = PacketSerializer.Serialize(packet);
-                        foreach (var chunk in chunks)
-                        {
-                            if (cancellationToken.IsCancellationRequested)
-                            {
-                                return;
-                            }
-
-                            await _channel.SendStream.WriteAsync(chunk.Array, chunk.Offset, chunk.Count, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-
                     if (cancellationToken.IsCancellationRequested)
                     {
                         return;
                     }
 
-                    if (timeout > TimeSpan.Zero)
+                    if (packet == null)
                     {
-                        await _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
+                        continue;
                     }
-                    else
+
+                    _logger.Verbose<MqttChannelAdapter>("TX >>> {0} [Timeout={1}]", packet, timeout);
+
+                    var packetData = PacketSerializer.Serialize(packet);
+                    if (cancellationToken.IsCancellationRequested)
                     {
-                        await _channel.SendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        return;
                     }
+                    await _channel.SendStream.WriteAsync(packetData.Array, packetData.Offset, (int)packetData.Count, cancellationToken).ConfigureAwait(false);
+
                 }
-                finally
+
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    _semaphore.Release();
+                    return;
+                }
+
+                if (timeout > TimeSpan.Zero)
+                {
+                    await _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _channel.SendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             });
         }

--- a/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
@@ -115,9 +115,13 @@ namespace MQTTnet.Adapter
                 ReceivedMqttPacket receivedMqttPacket = null;
                 try
                 {
+
                     if (timeout > TimeSpan.Zero)
                     {
-                        receivedMqttPacket = await ReceiveAsync(_channel.ReceiveStream, cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
+                        var timeoutCts = new CancellationTokenSource(timeout);
+                        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+                        receivedMqttPacket = await ReceiveAsync(_channel.ReceiveStream, linkedCts.Token).ConfigureAwait(false);
                     }
                     else
                     {

--- a/Frameworks/MQTTnet.NetStandard/Client/MqttPacketDispatcher.cs
+++ b/Frameworks/MQTTnet.NetStandard/Client/MqttPacketDispatcher.cs
@@ -10,7 +10,8 @@ namespace MQTTnet.Client
 {
     public class MqttPacketDispatcher
     {
-        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<ushort, TaskCompletionSource<MqttBasePacket>>> _awaiters = new ConcurrentDictionary<Type, ConcurrentDictionary<ushort, TaskCompletionSource<MqttBasePacket>>>();
+        
+        private readonly ConcurrentDictionary<Tuple<ushort?, Type>, TaskCompletionSource<MqttBasePacket>> _awaiters = new ConcurrentDictionary<Tuple<ushort?, Type>, TaskCompletionSource<MqttBasePacket>>();
         private readonly IMqttNetLogger _logger;
 
         public MqttPacketDispatcher(IMqttNetLogger logger)
@@ -22,7 +23,7 @@ namespace MQTTnet.Client
         {
             var packetAwaiter = AddPacketAwaiter(responseType, identifier);
             try
-            {
+            {                
                 return await packetAwaiter.Task.TimeoutAfter(timeout).ConfigureAwait(false);
             }
             catch (MqttCommunicationTimedOutException)
@@ -40,21 +41,20 @@ namespace MQTTnet.Client
         {
             if (packet == null) throw new ArgumentNullException(nameof(packet));
 
-            var type = packet.GetType();
-
-            if (_awaiters.TryGetValue(type, out var byId))
+            ushort? identifier = 0;
+            if (packet is IMqttPacketWithIdentifier packetWithIdentifier)
             {
-                ushort? identifier = 0;
-                if (packet is IMqttPacketWithIdentifier packetWithIdentifier)
-                {
-                    identifier = packetWithIdentifier.PacketIdentifier;
-                }
+                identifier = packetWithIdentifier.PacketIdentifier;
+            }
 
-                if (byId.TryRemove(identifier.Value, out var tcs))
-                {
-                    tcs.TrySetResult(packet);
-                    return;
-                }
+            var type = packet.GetType();
+            var key = new Tuple<ushort?, Type>(identifier, type);
+              
+
+            if (_awaiters.TryRemove(key, out var tcs))
+            {
+                tcs.TrySetResult(packet);
+                return;
             }
 
             throw new InvalidOperationException($"Packet of type '{type.Name}' not handled or dispatched.");
@@ -74,8 +74,8 @@ namespace MQTTnet.Client
                 identifier = 0;
             }
 
-            var byId = _awaiters.GetOrAdd(responseType, key => new ConcurrentDictionary<ushort, TaskCompletionSource<MqttBasePacket>>());
-            if (!byId.TryAdd(identifier.Value, tcs))
+            var dictionaryKey = new Tuple<ushort?,Type>(identifier, responseType);            
+            if (!_awaiters.TryAdd(dictionaryKey,tcs))
             {
                 throw new InvalidOperationException($"The packet dispatcher already has an awaiter for packet of type '{responseType}' with identifier {identifier}.");
             }
@@ -90,8 +90,8 @@ namespace MQTTnet.Client
                 identifier = 0;
             }
 
-            var byId = _awaiters.GetOrAdd(responseType, key => new ConcurrentDictionary<ushort, TaskCompletionSource<MqttBasePacket>>());
-            byId.TryRemove(identifier.Value, out var _);
+            var dictionaryKey = new Tuple<ushort?, Type>(identifier, responseType);
+            _awaiters.TryRemove(dictionaryKey, out var _);
         }
     }
 }

--- a/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpChannel.cs
+++ b/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpChannel.cs
@@ -60,6 +60,7 @@ namespace MQTTnet.Implementations
             if (_socket == null)
             {
                 _socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                
             }
 
 #if NET452 || NET461
@@ -67,6 +68,8 @@ namespace MQTTnet.Implementations
 #else
             await _socket.ConnectAsync(_options.Server, _options.GetPort()).ConfigureAwait(false);
 #endif
+
+            _socket.NoDelay = true;
 
             if (_options.TlsOptions.UseTls)
             {

--- a/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpServerAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpServerAdapter.cs
@@ -39,6 +39,8 @@ namespace MQTTnet.Implementations
             if (options.DefaultEndpointOptions.IsEnabled)
             {
                 _defaultEndpointSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                _defaultEndpointSocket.NoDelay = true;
+
                 _defaultEndpointSocket.Bind(new IPEndPoint(options.DefaultEndpointOptions.BoundIPAddress, options.GetDefaultEndpointPort()));
                 _defaultEndpointSocket.Listen(options.ConnectionBacklog);
 
@@ -102,7 +104,7 @@ namespace MQTTnet.Implementations
 #else
                     var clientSocket = await _defaultEndpointSocket.AcceptAsync().ConfigureAwait(false);
 #endif
-
+                    clientSocket.NoDelay=true;
                     var clientAdapter = new MqttChannelAdapter(new MqttTcpChannel(clientSocket, null), new MqttPacketSerializer(), _logger);
                     ClientAccepted?.Invoke(this, new MqttServerAdapterClientAcceptedEventArgs(clientAdapter));
                 }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/IMqttPacketSerializer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/IMqttPacketSerializer.cs
@@ -9,7 +9,7 @@ namespace MQTTnet.Serializer
     {
         MqttProtocolVersion ProtocolVersion { get; set; }
 
-        ICollection<ArraySegment<byte>> Serialize(MqttBasePacket mqttPacket);
+        ArraySegment<byte> Serialize(MqttBasePacket mqttPacket);
 
         MqttBasePacket Deserialize(MqttPacketHeader header, MemoryStream body);
     }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketWriter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using MQTTnet.Protocol;
 
@@ -55,13 +56,15 @@ namespace MQTTnet.Serializer
             Write(value);
         }
 
-        public static void WriteRemainingLength(int length, BinaryWriter target)
+        public static byte[] GetRemainingLength(int length)
         {
             if (length == 0)
             {
-                target.Write((byte)0);
-                return;
+                return new byte[] { (byte)0 };
             }
+
+            var bytes = new byte[4];
+            int arraySize = 0;
 
             // Alorithm taken from http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html.
             var x = length;
@@ -74,8 +77,12 @@ namespace MQTTnet.Serializer
                     encodedByte = encodedByte | 128;
                 }
 
-                target.Write((byte)encodedByte);
+                bytes[arraySize] = (byte)encodedByte;
+
+                arraySize++;
             } while (x > 0);
+
+            return bytes.Take(arraySize).ToArray();
         }
     }
 }


### PR DESCRIPTION
This PR improves throughput by 2x by disabling nagle algorithm on sockets. 
As many MQTT packets can fit into a single packet, we can avoid sockets lingering waiting for more bytes and send packets right away. 
I also refactored the packet serialization to construct a buffer with the header in the right position so we don't need to write to the socket twice per packet, which would cause two tcp packets to be sent over the wire for each mqtt packet. Doing that also allowed me to remove a semaphore that could bottleneck access to the socket.
 