### PR TITLE
Optmizations

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Adapter/IMqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/IMqttChannelAdapter.cs
@@ -15,7 +15,7 @@ namespace MQTTnet.Adapter
 
         Task DisconnectAsync(TimeSpan timeout);
 
-        Task SendPacketsAsync(TimeSpan timeout, CancellationToken cancellationToken, IEnumerable<MqttBasePacket> packets);
+        Task SendPacketsAsync(TimeSpan timeout, CancellationToken cancellationToken, MqttBasePacket[] packets);
 
         Task<MqttBasePacket> ReceivePacketAsync(TimeSpan timeout, CancellationToken cancellationToken);
     }

--- a/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -55,52 +56,41 @@ namespace MQTTnet.Adapter
 
             return ExecuteAndWrapExceptionAsync(async () =>
             {
-                await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
+                foreach (var packet in packets)
                 {
-                    foreach (var packet in packets)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            return;
-                        }
-
-                        if (packet == null)
-                        {
-                            continue;
-                        }
-
-                        _logger.Verbose<MqttChannelAdapter>("TX >>> {0} [Timeout={1}]", packet, timeout);
-
-                        var chunks = PacketSerializer.Serialize(packet);
-                        foreach (var chunk in chunks)
-                        {
-                            if (cancellationToken.IsCancellationRequested)
-                            {
-                                return;
-                            }
-
-                            await _channel.SendStream.WriteAsync(chunk.Array, chunk.Offset, chunk.Count, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-
                     if (cancellationToken.IsCancellationRequested)
                     {
                         return;
                     }
 
-                    if (timeout > TimeSpan.Zero)
+                    if (packet == null)
                     {
-                        await _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
+                        continue;
                     }
-                    else
+
+                    _logger.Verbose<MqttChannelAdapter>("TX >>> {0} [Timeout={1}]", packet, timeout);
+
+                    var packetData = PacketSerializer.Serialize(packet);
+                    if (cancellationToken.IsCancellationRequested)
                     {
-                        await _channel.SendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        return;
                     }
+                    await _channel.SendStream.WriteAsync(packetData.Array, packetData.Offset, (int)packetData.Count, cancellationToken).ConfigureAwait(false);
+
                 }
-                finally
+
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    _semaphore.Release();
+                    return;
+                }
+
+                if (timeout > TimeSpan.Zero)
+                {
+                    await _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _channel.SendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             });
         }

--- a/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
@@ -76,7 +76,11 @@ namespace MQTTnet.Adapter
                     {
                         return;
                     }
-                    await _channel.SendStream.WriteAsync(packetData.Array, packetData.Offset, (int)packetData.Count, cancellationToken).ConfigureAwait(false);
+                    await _channel.SendStream.WriteAsync(
+                        packetData.Array,
+                        packetData.Offset,
+                        (int)packetData.Count,
+                        cancellationToken).ConfigureAwait(false);
 
                 }
 
@@ -85,14 +89,6 @@ namespace MQTTnet.Adapter
                     return;
                 }
 
-                if (timeout > TimeSpan.Zero)
-                {
-                    await _channel.SendStream.FlushAsync(cancellationToken).TimeoutAfter(timeout).ConfigureAwait(false);
-                }
-                else
-                {
-                    await _channel.SendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
-                }
             });
         }
 

--- a/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Adapter/MqttChannelAdapter.cs
@@ -84,10 +84,7 @@ namespace MQTTnet.Adapter
 
                 }
 
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
+                
 
             });
         }

--- a/Frameworks/MQTTnet.NetStandard/Exceptions/MqttCommunicationTimedOutException.cs
+++ b/Frameworks/MQTTnet.NetStandard/Exceptions/MqttCommunicationTimedOutException.cs
@@ -1,6 +1,11 @@
-﻿namespace MQTTnet.Exceptions
+﻿using System;
+
+namespace MQTTnet.Exceptions
 {
     public sealed class MqttCommunicationTimedOutException : MqttCommunicationException
     {
+        public MqttCommunicationTimedOutException() : base() { }
+        public MqttCommunicationTimedOutException(Exception innerException) : base(innerException) { }
+
     }
 }

--- a/Frameworks/MQTTnet.NetStandard/Exceptions/MqttCommunicationTimedOutException.cs
+++ b/Frameworks/MQTTnet.NetStandard/Exceptions/MqttCommunicationTimedOutException.cs
@@ -4,7 +4,7 @@ namespace MQTTnet.Exceptions
 {
     public sealed class MqttCommunicationTimedOutException : MqttCommunicationException
     {
-        public MqttCommunicationTimedOutException() : base() { }
+        public MqttCommunicationTimedOutException() { }
         public MqttCommunicationTimedOutException(Exception innerException) : base(innerException) { }
 
     }

--- a/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpChannel.cs
+++ b/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpChannel.cs
@@ -60,6 +60,7 @@ namespace MQTTnet.Implementations
             if (_socket == null)
             {
                 _socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                
             }
 
 #if NET452 || NET461
@@ -67,6 +68,8 @@ namespace MQTTnet.Implementations
 #else
             await _socket.ConnectAsync(_options.Server, _options.GetPort()).ConfigureAwait(false);
 #endif
+
+            _socket.NoDelay = true;
 
             if (_options.TlsOptions.UseTls)
             {

--- a/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpServerAdapter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Implementations/MqttTcpServerAdapter.cs
@@ -39,6 +39,8 @@ namespace MQTTnet.Implementations
             if (options.DefaultEndpointOptions.IsEnabled)
             {
                 _defaultEndpointSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                _defaultEndpointSocket.NoDelay = true;
+
                 _defaultEndpointSocket.Bind(new IPEndPoint(options.DefaultEndpointOptions.BoundIPAddress, options.GetDefaultEndpointPort()));
                 _defaultEndpointSocket.Listen(options.ConnectionBacklog);
 
@@ -102,7 +104,7 @@ namespace MQTTnet.Implementations
 #else
                     var clientSocket = await _defaultEndpointSocket.AcceptAsync().ConfigureAwait(false);
 #endif
-
+                    clientSocket.NoDelay=true;
                     var clientAdapter = new MqttChannelAdapter(new MqttTcpChannel(clientSocket, null), new MqttPacketSerializer(), _logger);
                     ClientAccepted?.Invoke(this, new MqttServerAdapterClientAcceptedEventArgs(clientAdapter));
                 }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/IMqttPacketSerializer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/IMqttPacketSerializer.cs
@@ -9,7 +9,7 @@ namespace MQTTnet.Serializer
     {
         MqttProtocolVersion ProtocolVersion { get; set; }
 
-        ICollection<ArraySegment<byte>> Serialize(MqttBasePacket mqttPacket);
+        ArraySegment<byte> Serialize(MqttBasePacket mqttPacket);
 
         MqttBasePacket Deserialize(MqttPacketHeader header, MemoryStream body);
     }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketWriter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using MQTTnet.Protocol;
 
@@ -55,13 +56,15 @@ namespace MQTTnet.Serializer
             Write(value);
         }
 
-        public static void WriteRemainingLength(int length, BinaryWriter target)
+        public static byte[] GetRemainingLength(int length)
         {
             if (length == 0)
             {
-                target.Write((byte)0);
-                return;
+                return new byte[] { (byte)0 };
             }
+
+            var bytes = new byte[4];
+            int arraySize = 0;
 
             // Alorithm taken from http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html.
             var x = length;
@@ -74,8 +77,12 @@ namespace MQTTnet.Serializer
                     encodedByte = encodedByte | 128;
                 }
 
-                target.Write((byte)encodedByte);
+                bytes[arraySize] = (byte)encodedByte;
+
+                arraySize++;
             } while (x > 0);
+
+            return bytes.Take(arraySize).ToArray();
         }
     }
 }

--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketWriter.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketWriter.cs
@@ -58,9 +58,9 @@ namespace MQTTnet.Serializer
 
         public static byte[] GetRemainingLength(int length)
         {
-            if (length == 0)
+            if (length <= 0)
             {
-                return new byte[] { (byte)0 };
+                return new [] { (byte)0 };
             }
 
             var bytes = new byte[4];

--- a/Tests/MQTTnet.Core.Tests/MqttPacketSerializerTests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttPacketSerializerTests.cs
@@ -403,9 +403,9 @@ namespace MQTTnet.Core.Tests
         private static void SerializeAndCompare(MqttBasePacket packet, string expectedBase64Value, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
         {
             var serializer = new MqttPacketSerializer { ProtocolVersion = protocolVersion };
-            var chunks = serializer.Serialize(packet);
+            var data = serializer.Serialize(packet);
             
-            Assert.AreEqual(expectedBase64Value, Convert.ToBase64String(Join(chunks)));
+            Assert.AreEqual(expectedBase64Value, Convert.ToBase64String(Join(data)));
         }
 
         private static void DeserializeAndCompare(MqttBasePacket packet, string expectedBase64Value, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
@@ -429,6 +429,17 @@ namespace MQTTnet.Core.Tests
         }
 
         private static byte[] Join(IEnumerable<ArraySegment<byte>> chunks)
+        {
+            var buffer = new MemoryStream();
+            foreach (var chunk in chunks)
+            {
+                buffer.Write(chunk.Array, chunk.Offset, chunk.Count);
+            }
+
+            return buffer.ToArray();
+        }
+
+        private static byte[] Join(params ArraySegment<byte>[] chunks)
         {
             var buffer = new MemoryStream();
             foreach (var chunk in chunks)

--- a/Tests/MQTTnet.Core.Tests/TestMqttCommunicationAdapter.cs
+++ b/Tests/MQTTnet.Core.Tests/TestMqttCommunicationAdapter.cs
@@ -31,7 +31,7 @@ namespace MQTTnet.Core.Tests
             return Task.FromResult(0);
         }
 
-        public Task SendPacketsAsync(TimeSpan timeout, CancellationToken cancellationToken, IEnumerable<MqttBasePacket> packets)
+        public Task SendPacketsAsync(TimeSpan timeout, CancellationToken cancellationToken, MqttBasePacket[] packets)
         {
             ThrowIfPartnerIsNull();
 


### PR DESCRIPTION
This PR improves throughput by 2x by disabling nagle algorithm on sockets.
As many MQTT packets can fit into a single tcp packet, we can avoid sockets lingering waiting for more bytes and send packets right away.
I also refactored the packet serialization to construct a buffer with the header in the right position so we don't need to write to the socket twice per packet, which would cause two tcp packets to be sent over the wire for each mqtt packet. Doing that also allowed me to remove a semaphore that could bottleneck access to the socket.