### PR TITLE
New topic matcher

### DIFF
--- a/Frameworks/MQTTnet.AspnetCore/ApplicationBuilderExtensions.cs
+++ b/Frameworks/MQTTnet.AspnetCore/ApplicationBuilderExtensions.cs
@@ -17,12 +17,11 @@ namespace MQTTnet.AspNetCore
                 {
                     string subprotocol = null;
 
-                    if (context.Request.Headers.TryGetValue("Sec-WebSocket-Protocol", out var requestedSubProtocolValues)
-                     && requestedSubProtocolValues.Count > 0
-                     && requestedSubProtocolValues.Any(v => v.ToLower() == "mqtt")
-                     )
+                    if (context.Request.Headers.TryGetValue("Sec-WebSocket-Protocol", out var requestedSubProtocolValues))
                     {
-                        subprotocol = "mqtt";
+                        subprotocol = requestedSubProtocolValues
+                                .OrderByDescending(p => p.Length)
+                                .FirstOrDefault(p => p.ToLower().StartsWith("mqtt"));
                     }
 
                     var adapter = app.ApplicationServices.GetRequiredService<MqttWebSocketServerAdapter>();

--- a/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptions.cs
+++ b/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptions.cs
@@ -1,0 +1,12 @@
+﻿using MQTTnet.Server;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MQTTnet.AspNetCore
+{
+    public class AspNetMqttServerOptions : MqttServerOptions, IAspNetMqttServerOptions
+    {
+        public Boolean ListenTcp { get; set; } = true;
+    }
+}

--- a/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptionsBuilder.cs
+++ b/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptionsBuilder.cs
@@ -1,0 +1,34 @@
+﻿using MQTTnet.Server;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MQTTnet.AspNetCore
+{
+    public class AspNetMqttServerOptionsBuilder : MqttServerOptionsBuilder
+    {
+
+        private AspNetMqttServerOptions _aspNetOptions => (AspNetMqttServerOptions)_options;
+
+        public AspNetMqttServerOptionsBuilder():base(new AspNetMqttServerOptions())
+        {
+            
+        }
+
+        public AspNetMqttServerOptionsBuilder WithListenTcp(bool value)
+        {
+            _aspNetOptions.ListenTcp = value;
+            return this;
+        }
+
+        public new IAspNetMqttServerOptions Build()
+        {
+            return _aspNetOptions;
+        }
+
+    }
+
+    
+
+  
+}

--- a/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptionsBuilder.cs
+++ b/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptionsBuilder.cs
@@ -8,7 +8,6 @@ namespace MQTTnet.AspNetCore
     public class AspNetMqttServerOptionsBuilder : MqttServerOptionsBuilder
     {
 
-        private AspNetMqttServerOptions _aspNetOptions { get { return (AspNetMqttServerOptions)_options; } }
 
         public AspNetMqttServerOptionsBuilder():base(new AspNetMqttServerOptions())
         {
@@ -17,13 +16,13 @@ namespace MQTTnet.AspNetCore
 
         public AspNetMqttServerOptionsBuilder WithListenTcp(bool value)
         {
-            _aspNetOptions.ListenTcp = value;
+            ((AspNetMqttServerOptions)(_options)).ListenTcp = value;
             return this;
         }
 
         public new IAspNetMqttServerOptions Build()
         {
-            return _aspNetOptions;
+            return (AspNetMqttServerOptions)_options;
         }
 
     }

--- a/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptionsBuilder.cs
+++ b/Frameworks/MQTTnet.AspnetCore/AspNetMqttServerOptionsBuilder.cs
@@ -8,7 +8,7 @@ namespace MQTTnet.AspNetCore
     public class AspNetMqttServerOptionsBuilder : MqttServerOptionsBuilder
     {
 
-        private AspNetMqttServerOptions _aspNetOptions => (AspNetMqttServerOptions)_options;
+        private AspNetMqttServerOptions _aspNetOptions { get { return (AspNetMqttServerOptions)_options; } }
 
         public AspNetMqttServerOptionsBuilder():base(new AspNetMqttServerOptions())
         {

--- a/Frameworks/MQTTnet.AspnetCore/IAspNetMqttServerOptions.cs
+++ b/Frameworks/MQTTnet.AspnetCore/IAspNetMqttServerOptions.cs
@@ -1,0 +1,12 @@
+﻿using MQTTnet.Server;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MQTTnet.AspNetCore
+{
+    public interface IAspNetMqttServerOptions : IMqttServerOptions
+    {
+        Boolean ListenTcp { get; }
+    }
+}

--- a/Frameworks/MQTTnet.AspnetCore/ServiceCollectionExtensions.cs
+++ b/Frameworks/MQTTnet.AspnetCore/ServiceCollectionExtensions.cs
@@ -12,7 +12,19 @@ namespace MQTTnet.AspNetCore
 
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddHostedMqttServer(this IServiceCollection services, Action<AspNetMqttServerOptionsBuilder> configureOptions=null)
+
+        public static IServiceCollection AddHostedMqttServer(this IServiceCollection services)
+        {
+            return AddHostedMqttServerInternal(services, null);
+        }
+
+
+        public static IServiceCollection AddHostedMqttServer(this IServiceCollection services, Action<AspNetMqttServerOptionsBuilder> configureOptions)
+        {
+            return AddHostedMqttServerInternal(services, configureOptions);
+        }
+
+        private static IServiceCollection AddHostedMqttServerInternal(this IServiceCollection services, Action<AspNetMqttServerOptionsBuilder> configureOptions = null)
         {
             var builder = new AspNetMqttServerOptionsBuilder();
 
@@ -26,19 +38,17 @@ namespace MQTTnet.AspNetCore
             services.AddSingleton<MqttHostedServer>();
             services.AddSingleton<IHostedService>(s => s.GetService<MqttHostedServer>());
             services.AddSingleton<IMqttServer>(s => s.GetService<MqttHostedServer>());
-            
-            services.AddSingleton<MqttWebSocketServerAdapter>();            
+
+            services.AddSingleton<MqttWebSocketServerAdapter>();
             services.AddSingleton<IMqttServerAdapter>(s => s.GetService<MqttWebSocketServerAdapter>());
 
             if (options.ListenTcp)
             {
                 services.AddSingleton<MqttTcpServerAdapter>();
                 services.AddSingleton<IMqttServerAdapter>(s => s.GetService<MqttTcpServerAdapter>());
-            }           
+            }
 
             return services;
         }
-
-        
     }
 }

--- a/Frameworks/MQTTnet.AspnetCore/ServiceCollectionExtensions.cs
+++ b/Frameworks/MQTTnet.AspnetCore/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace MQTTnet.AspNetCore
 
         public static IServiceCollection AddHostedMqttServer(this IServiceCollection services)
         {
-            return AddHostedMqttServerInternal(services, null);
+            return AddHostedMqttServerInternal(services);
         }
 
 

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttServerOptionsBuilder.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttServerOptionsBuilder.cs
@@ -5,7 +5,17 @@ namespace MQTTnet.Server
 {
     public class MqttServerOptionsBuilder
     {
-        private readonly MqttServerOptions _options = new MqttServerOptions();
+        protected readonly MqttServerOptions _options;
+
+        public MqttServerOptionsBuilder()
+        {
+            _options =new MqttServerOptions();
+        }
+
+        public MqttServerOptionsBuilder(MqttServerOptions options)
+        {
+            _options = options;
+        }
 
         public MqttServerOptionsBuilder WithConnectionBacklog(int value)
         {

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttTopicFilterComparer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttTopicFilterComparer.cs
@@ -6,39 +6,115 @@ namespace MQTTnet.Server
     {
         private static readonly char[] TopicLevelSeparator = { '/' };
 
-        public static bool IsMatch(string topic, string filter)
+        public static bool IsMatch(string topic, string sub)
         {
-            if (topic == null) throw new ArgumentNullException(nameof(topic));
-            if (filter == null) throw new ArgumentNullException(nameof(filter));
+            if (string.IsNullOrEmpty(topic)) throw new ArgumentNullException(nameof(topic));
+            if (string.IsNullOrEmpty(sub)) throw new ArgumentNullException(nameof(sub));
 
-            if (string.Equals(topic, filter, StringComparison.Ordinal))
+
+            var spos = 0;
+            var slen = sub.Length;
+            var tpos = 0;
+            var tlen = topic.Length;
+                        
+            var multilevel_wildcard = false;
+
+            while (spos < slen && tpos <= tlen)
             {
-                return true;
+                if (sub[spos] == topic[tpos])
+                {
+                    if (tpos == tlen - 1)
+                    {
+                        /* Check for e.g. foo matching foo/# */
+                        if (spos == slen - 3
+                                && sub[spos + 1] == '/'
+                                && sub[spos + 2] == '#')
+                        {
+                            multilevel_wildcard = true;
+                            return true;
+                        }
+                    }
+                    spos++;
+                    tpos++;
+                    if (spos == slen && tpos == tlen)
+                    {
+                        return true;
+                    }
+                    else if (tpos == tlen && spos == slen - 1 && sub[spos] == '+')
+                    {
+                        if (spos > 0 && sub[spos - 1] != '/')
+                        {
+                            throw new ArgumentException("Invalid filter string", "filter");
+                        }
+                        spos++;
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (sub[spos] == '+')
+                    {
+                        /* Check for bad "+foo" or "a/+foo" subscription */
+                        if (spos > 0 && sub[spos - 1] != '/')
+                        {
+                            throw new ArgumentException("Invalid filter string", "filter");
+                        }
+                        /* Check for bad "foo+" or "foo+/a" subscription */
+                        if (spos < slen - 1 && sub[spos + 1] != '/')
+                        {
+                            throw new ArgumentException("Invalid filter string", "filter");
+                        }
+                        spos++;
+                        while (tpos < tlen && topic[tpos] != '/')
+                        {
+                            tpos++;
+                        }
+                        if (tpos == tlen && spos == slen)
+                        {
+                            return true;
+                        }
+                    }
+                    else if (sub[spos] == '#')
+                    {
+                        if (spos > 0 && sub[spos - 1] != '/')
+                        {
+                            throw new ArgumentException("Invalid filter string", "filter");
+                        }
+                        multilevel_wildcard = true;
+                        if (spos + 1 != slen)
+                        {
+                            throw new ArgumentException("Invalid filter string", "filter");
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        /* Check for e.g. foo/bar matching foo/+/# */
+                        if (spos > 0
+                                && spos + 2 == slen
+                                && tpos == tlen
+                                && sub[spos - 1] == '+'
+                                && sub[spos] == '/'
+                                && sub[spos + 1] == '#')
+                        {
+                            multilevel_wildcard = true;
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+            }
+            if (multilevel_wildcard == false && (tpos < tlen || spos < slen))
+            {
+                return false;
             }
 
-            var fragmentsTopic = topic.Split(TopicLevelSeparator, StringSplitOptions.None);
-            var fragmentsFilter = filter.Split(TopicLevelSeparator, StringSplitOptions.None);
+            return false;
 
-            for (var i = 0; i < fragmentsFilter.Length; i++)
-            {
-                switch (fragmentsFilter[i])
-                {
-                    case "+": continue;
-                    case "#" when i == fragmentsFilter.Length - 1: return true;
-                }
-
-                if (i >= fragmentsTopic.Length)
-                {
-                    return false;
-                }
-
-                if (!string.Equals(fragmentsFilter[i], fragmentsTopic[i], StringComparison.Ordinal))
-                {
-                    return false;
-                }
-            }
-
-            return fragmentsTopic.Length <= fragmentsFilter.Length;
+         
         }
     }
 }

--- a/Tests/MQTTnet.TestApp.AspNetCore2/Startup.cs
+++ b/Tests/MQTTnet.TestApp.AspNetCore2/Startup.cs
@@ -16,8 +16,10 @@ namespace MQTTnet.TestApp.AspNetCore2
 
         public void ConfigureServices(IServiceCollection services)
         {
-            var mqttServerOptions = new MqttServerOptionsBuilder().Build();
-            services.AddHostedMqttServer(mqttServerOptions);
+            services.AddHostedMqttServer(options=> {
+                //set to false to listen only on websockets
+                options.WithListenTcp(false);
+            });
         }
 
         // In class _Startup_ of the ASP.NET Core 2.0 project.


### PR DESCRIPTION
This implements a new topic matcher that does not allocate in the heap. String.split allocates a new string for each split item.
Took the implementation from mosquitto as reference
https://github.com/eclipse/mosquitto/blob/4f838e51611b9a71f2e3e98e6fddd02a5c1b4c03/lib/util_mosq.c