### PR TITLE
Removal of StaleSessions

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Server/IMqttServerOptions.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/IMqttServerOptions.cs
@@ -5,8 +5,13 @@ namespace MQTTnet.Server
     public interface IMqttServerOptions
     {
         int ConnectionBacklog { get; }
+
         int MaxPendingMessagesPerClient { get; }
         MqttPendingMessagesOverflowStrategy PendingMessagesOverflowStrategy { get; }
+        /// <summary>
+        /// How long server keeps sessions in memory after last packet/KeepAlive receeived. Be generous, if this setting is shorter than KeepAlive, it will close even Live connections!
+        /// </summary>
+        TimeSpan StaleSessionLifetime { get; }
 
         TimeSpan DefaultCommunicationTimeout { get; }
 

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttClientPendingMessagesQueue.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttClientPendingMessagesQueue.cs
@@ -58,6 +58,7 @@ namespace MQTTnet.Server
 
             if (_queue.Count >= _options.MaxPendingMessagesPerClient)
             {
+                _logger.Info($"ClientId: {_clientSession.ClientId} exceeded MaxPendingQueLength, dropping packets while Connected is {_clientSession.IsConnected}");
                 if (_options.PendingMessagesOverflowStrategy == MqttPendingMessagesOverflowStrategy.DropNewMessage)
                 {
                     return;
@@ -72,7 +73,7 @@ namespace MQTTnet.Server
             _queue.Enqueue(packet);
             _queueAutoResetEvent.Set();
 
-            _logger.Verbose("Enqueued packet (ClientId: {0}).", _clientSession.ClientId);
+            _logger.Verbose($"Enqueued packet (ClientId: {_clientSession.ClientId}).");
         }
 
         private async Task SendQueuedPacketsAsync(IMqttChannelAdapter adapter, CancellationToken cancellationToken)

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttClientSession.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttClientSession.cs
@@ -84,11 +84,11 @@ namespace MQTTnet.Server
             }
             catch (MqttCommunicationException exception)
             {
-                _logger.Warning(exception, "Client '{0}': Communication exception while processing client packets.", ClientId);
+                _logger.Warning(exception, $"Client '{ClientId}': Communication exception while processing client packets.");
             }
             catch (Exception exception)
             {
-                _logger.Error(exception, "Client '{0}': Unhandled exception while processing client packets.", ClientId);
+                _logger.Error(exception, $"Client '{ClientId}': Unhandled exception while processing client packets.");
             }
             finally
             {

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttClientSessionsManager.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttClientSessionsManager.cs
@@ -182,7 +182,6 @@ namespace MQTTnet.Server
             finally
             {
                 _sessionsLock.Exit();
-                _cancellationTokenSource = null;
             }
         }
 
@@ -257,6 +256,7 @@ namespace MQTTnet.Server
         {
             _sessionsLock?.Dispose();
             _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = null;
         }
 
         private MqttConnectReturnCode ValidateConnection(MqttConnectPacket connectPacket)

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttClientSessionsManager.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttClientSessionsManager.cs
@@ -20,6 +20,8 @@ namespace MQTTnet.Server
         private readonly MqttRetainedMessagesManager _retainedMessagesManager;
         private readonly IMqttServerOptions _options;
         private readonly IMqttNetChildLogger _logger;
+        private CancellationTokenSource _cancellationTokenSource;
+        private Task _StaleSessionMonitor; 
 
         public MqttClientSessionsManager(IMqttServerOptions options, MqttServer server, MqttRetainedMessagesManager retainedMessagesManager, IMqttNetChildLogger logger)
         {
@@ -30,6 +32,8 @@ namespace MQTTnet.Server
             _options = options ?? throw new ArgumentNullException(nameof(options));
             Server = server ?? throw new ArgumentNullException(nameof(server));
             _retainedMessagesManager = retainedMessagesManager ?? throw new ArgumentNullException(nameof(retainedMessagesManager));
+            _cancellationTokenSource = new CancellationTokenSource();
+            _StaleSessionMonitor = Task.Run(() => RunStaleSessionsMonitor(_cancellationTokenSource.Token).ConfigureAwait(false));
         }
 
         public MqttServer Server { get; }
@@ -117,21 +121,68 @@ namespace MQTTnet.Server
             }
         }
 
+        private async Task RunStaleSessionsMonitor(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                Dictionary<string, MqttClientSession> staleSessionIds = new Dictionary<string, MqttClientSession>();
+                string clientID = "Unassigned";
+                await _sessionsLock.EnterAsync(CancellationToken.None).ConfigureAwait(false);
+
+                try
+                {
+                    staleSessionIds = new Dictionary<string, MqttClientSession>();
+                    foreach (var sessionEntry in _sessions)
+                    {
+                        clientID = sessionEntry.Key; 
+                        if (sessionEntry.Value.KeepAliveMonitor.LastPacketReceived > _options.StaleSessionLifetime)
+                        {
+                            staleSessionIds.Add(clientID, sessionEntry.Value);
+                        }
+                    }
+                    foreach(var sessionEntry in staleSessionIds)
+                    {
+                        _sessions.Remove(sessionEntry.Key);
+                        _logger.Info($"Removed StaleSession for Client '{clientID}' after timeout");
+                    }
+                }
+                catch(Exception exception)
+                {
+                    _logger.Error(exception, $"Unhandled exception while attempting to close stale session for Client '{clientID}'");
+                }
+                finally
+                {
+                    _sessionsLock.Exit();
+                }
+
+                Parallel.ForEach(staleSessionIds, sessionEntry =>
+                   {
+                       sessionEntry.Value.Stop(MqttClientDisconnectType.NotClean);
+                       sessionEntry.Value.Dispose();
+                   });
+                await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         public async Task StopAsync()
         {
             await _sessionsLock.EnterAsync(CancellationToken.None).ConfigureAwait(false);
             try
             {
+                if(_cancellationTokenSource == null){
+                    return; 
+                }
+                _cancellationTokenSource.Cancel(); 
                 foreach (var session in _sessions)
                 {
                     session.Value.Stop(MqttClientDisconnectType.NotClean);
                 }
-
                 _sessions.Clear();
             }
             finally
             {
                 _sessionsLock.Exit();
+                _cancellationTokenSource = null;
             }
         }
 
@@ -205,6 +256,7 @@ namespace MQTTnet.Server
         public void Dispose()
         {
             _sessionsLock?.Dispose();
+            _cancellationTokenSource?.Dispose();
         }
 
         private MqttConnectReturnCode ValidateConnection(MqttConnectPacket connectPacket)

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttServerOptions.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttServerOptions.cs
@@ -10,7 +10,9 @@ namespace MQTTnet.Server
 
         public int ConnectionBacklog { get; set; } = 10;
 
-        public int MaxPendingMessagesPerClient { get; set; } = 250;
+        public TimeSpan StaleSessionLifetime { get; set; } = TimeSpan.FromMinutes(10); 
+
+        public int MaxPendingMessagesPerClient { get; set; } = 1000;
 
         public MqttPendingMessagesOverflowStrategy PendingMessagesOverflowStrategy { get; set; } = MqttPendingMessagesOverflowStrategy.DropOldestQueuedMessage;
 

--- a/Frameworks/MQTTnet.NetStandard/Server/MqttServerOptionsBuilder.cs
+++ b/Frameworks/MQTTnet.NetStandard/Server/MqttServerOptionsBuilder.cs
@@ -19,6 +19,12 @@ namespace MQTTnet.Server
             return this;
         }
 
+        public MqttServerOptionsBuilder WithStaleSessionLifetime(TimeSpan value)
+        {
+            _options.StaleSessionLifetime = value;
+            return this;
+        }
+
         public MqttServerOptionsBuilder WithDefaultCommunicationTimeout(TimeSpan value)
         {
             _options.DefaultCommunicationTimeout = value;


### PR DESCRIPTION
I want to make I can be confident in the broker's memory footprint, and be sure that in the broker nothing hangs around forever. 

I have implemented lifetime for StaleSessions. The ClientSessionManager now has a task that runs every 2 seconds, and check how much time has passed since receiving last packet/keepalive. 
If time passed is greater than `StaleSessionLifetime` it will clear the session, and even kill the connection if it's still alive. 

Is this the behaviour we want to have? 
To my use-case  cleaning up old sessions is more important than putting a limit on the amount of messages pending in a single client session. 

I also noticed that you use "normal" Dictionary and locking, not concurrent dictionary. Are you doing this to improve performance? 
I have tried re-writing the Session manager with concurrent dictionary and the code becomes a lot simpler. 