### PR TITLE
Fix MqttProtocolVersion 3.1 client connection

### DIFF
--- a/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketSerializer.cs
+++ b/Frameworks/MQTTnet.NetStandard/Serializer/MqttPacketSerializer.cs
@@ -205,11 +205,7 @@ namespace MQTTnet.Serializer
             }
             else
             {
-                var buffer = new byte[6];
-                Array.Copy(protocolName, buffer, 4);
-                protocolName = stream.ReadBytes(2);
-                Array.Copy(protocolName, 0, buffer, 4, 2);
-
+                protocolName = protocolName.Concat(stream.ReadBytes(2)).ToArray();
                 if (protocolName.SequenceEqual(ProtocolVersionV310Name))
                 {
                     protocolVersion = MqttProtocolVersion.V310;


### PR DESCRIPTION
Hi @chkr1011 ,

There is a mistake with client using the version 3.1 (MQIsdp).

The condition  `if (protocolName.SequenceEqual(ProtocolVersionV310Name))` should be targeted on the `buffer` variable (otherwise a MqttProtocolViolationException is thrown).

I updated & simplified the code with LINQ extensions.

Best,