### PR TITLE
Improved Serializer memory usage

### DIFF
--- a/Source/MQTTnet/Adapter/ReceivedMqttPacket.cs
+++ b/Source/MQTTnet/Adapter/ReceivedMqttPacket.cs
@@ -1,10 +1,11 @@
 ﻿using MQTTnet.Serializer;
+using System;
 
 namespace MQTTnet.Adapter
 {
     public class ReceivedMqttPacket
     {
-        public ReceivedMqttPacket(byte fixedHeader, MqttPacketBodyReader body)
+        public ReceivedMqttPacket(byte fixedHeader, Memory<byte> body)
         {
             FixedHeader = fixedHeader;
             Body = body;
@@ -12,6 +13,6 @@ namespace MQTTnet.Adapter
 
         public byte FixedHeader { get; }
 
-        public MqttPacketBodyReader Body { get; }
+        public Memory<byte> Body { get; }
     }
 }

--- a/Source/MQTTnet/MQTTnet.csproj
+++ b/Source/MQTTnet/MQTTnet.csproj
@@ -16,6 +16,7 @@
     <PackageId />
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='uap10.0'">
@@ -60,6 +61,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5" />
+    <PackageReference Include="System.Buffers" Version="4.5" />
   </ItemGroup>
 
 </Project>

--- a/Source/MQTTnet/Serializer/IMqttPacketSerializer.cs
+++ b/Source/MQTTnet/Serializer/IMqttPacketSerializer.cs
@@ -8,7 +8,7 @@ namespace MQTTnet.Serializer
     {
         MqttProtocolVersion ProtocolVersion { get; set; }
 
-        ArraySegment<byte> Serialize(MqttBasePacket mqttPacket);
+        byte[] Serialize(MqttBasePacket mqttPacket);
 
         MqttBasePacket Deserialize(ReceivedMqttPacket receivedMqttPacket);
     }

--- a/Source/MQTTnet/Serializer/MemoryBufferWriter.cs
+++ b/Source/MQTTnet/Serializer/MemoryBufferWriter.cs
@@ -1,0 +1,353 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MQTTnet.Serializer
+{
+    //from https://github.com/aspnet/SignalR/blob/dev/src/Common/MemoryBufferWriter.cs
+
+    public sealed class MemoryBufferWriter : Stream, IBufferWriter<byte>
+    {
+        [ThreadStatic]
+        private static MemoryBufferWriter _cachedInstance;
+
+#if DEBUG
+        private bool _inUse;
+#endif
+
+        private readonly int _minimumSegmentSize;
+        private int _bytesWritten;
+
+        private List<CompletedBuffer> _completedSegments;
+        private byte[] _currentSegment;
+        private int _position;
+
+        public MemoryBufferWriter(int minimumSegmentSize = 4096)
+        {
+            _minimumSegmentSize = minimumSegmentSize;
+        }
+
+        public override long Length => _bytesWritten;
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public static MemoryBufferWriter Get()
+        {
+            var writer = _cachedInstance;
+            if (writer == null)
+            {
+                writer = new MemoryBufferWriter();
+            }
+            else
+            {
+                // Taken off the thread static
+                _cachedInstance = null;
+            }
+#if DEBUG
+            if (writer._inUse)
+            {
+                throw new InvalidOperationException("The reader wasn't returned!");
+            }
+
+            writer._inUse = true;
+#endif
+
+            return writer;
+        }
+
+        public static void Return(MemoryBufferWriter writer)
+        {
+            _cachedInstance = writer;
+#if DEBUG
+            writer._inUse = false;
+#endif
+            writer.Reset();
+        }
+
+        public void Reset()
+        {
+            if (_completedSegments != null)
+            {
+                for (var i = 0; i < _completedSegments.Count; i++)
+                {
+                    _completedSegments[i].Return();
+                }
+
+                _completedSegments.Clear();
+            }
+
+            if (_currentSegment != null)
+            {
+                ArrayPool<byte>.Shared.Return(_currentSegment);
+                _currentSegment = null;
+            }
+
+            _bytesWritten = 0;
+            _position = 0;
+        }
+
+        public void Advance(int count)
+        {
+            _bytesWritten += count;
+            _position += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+
+            return _currentSegment.AsMemory(_position, _currentSegment.Length - _position);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+
+            return _currentSegment.AsSpan(_position, _currentSegment.Length - _position);
+        }
+
+        public void CopyTo(IBufferWriter<byte> destination)
+        {
+            if (_completedSegments != null)
+            {
+                // Copy completed segments
+                var count = _completedSegments.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    destination.Write(_completedSegments[i].Span);
+                }
+            }
+
+            destination.Write(_currentSegment.AsSpan(0, _position));
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            if (_completedSegments == null)
+            {
+                // There is only one segment so write without awaiting.
+                return destination.WriteAsync(_currentSegment, 0, _position);
+            }
+
+            return CopyToSlowAsync(destination);
+        }
+
+        private void EnsureCapacity(int sizeHint)
+        {
+            // This does the Right Thing. It only subtracts _position from the current segment length if it's non-null.
+            // If _currentSegment is null, it returns 0.
+            var remainingSize = _currentSegment?.Length - _position ?? 0;
+
+            // If the sizeHint is 0, any capacity will do
+            // Otherwise, the buffer must have enough space for the entire size hint, or we need to add a segment.
+            if ((sizeHint == 0 && remainingSize > 0) || (sizeHint > 0 && remainingSize >= sizeHint))
+            {
+                // We have capacity in the current segment
+                return;
+            }
+
+            AddSegment(sizeHint);
+        }
+
+        private void AddSegment(int sizeHint = 0)
+        {
+            if (_currentSegment != null)
+            {
+                // We're adding a segment to the list
+                if (_completedSegments == null)
+                {
+                    _completedSegments = new List<CompletedBuffer>();
+                }
+
+                // Position might be less than the segment length if there wasn't enough space to satisfy the sizeHint when
+                // GetMemory was called. In that case we'll take the current segment and call it "completed", but need to
+                // ignore any empty space in it.
+                _completedSegments.Add(new CompletedBuffer(_currentSegment, _position));
+            }
+
+            // Get a new buffer using the minimum segment size, unless the size hint is larger than a single segment.
+            _currentSegment = ArrayPool<byte>.Shared.Rent(Math.Max(_minimumSegmentSize, sizeHint));
+            _position = 0;
+        }
+
+        private async Task CopyToSlowAsync(Stream destination)
+        {
+            if (_completedSegments != null)
+            {
+                // Copy full segments
+                var count = _completedSegments.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var segment = _completedSegments[i];
+                    await destination.WriteAsync(segment.Buffer, 0, segment.Length);
+                }
+            }
+
+            await destination.WriteAsync(_currentSegment, 0, _position);
+        }
+
+        
+
+        public byte[] ToArray()
+        {
+            if (_currentSegment == null)
+            {
+#if NET452
+                return new byte[0];
+#else
+                return Array.Empty<byte>();
+#endif
+            }
+
+            var result = new byte[_bytesWritten];
+
+            var totalWritten = 0;
+
+            if (_completedSegments != null)
+            {
+                // Copy full segments
+                var count = _completedSegments.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var segment = _completedSegments[i];
+                    segment.Span.CopyTo(result.AsSpan(totalWritten));
+                    totalWritten += segment.Span.Length;
+                }
+            }
+
+            // Copy current incomplete segment
+            _currentSegment.AsSpan(0, _position).CopyTo(result.AsSpan(totalWritten));
+
+            return result;
+        }
+
+        public void CopyTo(Span<byte> span)
+        {
+            Debug.Assert(span.Length >= _bytesWritten);
+
+            if (_currentSegment == null)
+            {
+                return;
+            }
+
+            var totalWritten = 0;
+
+            if (_completedSegments != null)
+            {
+                // Copy full segments
+                var count = _completedSegments.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var segment = _completedSegments[i];
+                    segment.Span.CopyTo(span.Slice(totalWritten));
+                    totalWritten += segment.Span.Length;
+                }
+            }
+
+            // Copy current incomplete segment
+            _currentSegment.AsSpan(0, _position).CopyTo(span.Slice(totalWritten));
+
+            Debug.Assert(_bytesWritten == totalWritten + _position);
+        }
+
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+#if NET452
+            return Task.FromResult(0);
+#else
+            return Task.CompletedTask;
+#endif
+        }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void WriteByte(byte value)
+        {
+            if (_currentSegment != null && (uint)_position < (uint)_currentSegment.Length)
+            {
+                _currentSegment[_position] = value;
+            }
+            else
+            {
+                AddSegment();
+                _currentSegment[0] = value;
+            }
+
+            _position++;
+            _bytesWritten++;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var position = _position;
+            if (_currentSegment != null && position < _currentSegment.Length - count)
+            {
+                Buffer.BlockCopy(buffer, offset, _currentSegment, position, count);
+
+                _position = position + count;
+                _bytesWritten += count;
+            }
+            else
+            {
+                BuffersExtensions.Write(this, buffer.AsSpan(offset, count));
+            }
+        }
+
+#if NETCOREAPP2_2
+        public override void Write(ReadOnlySpan<byte> span)
+        {
+            if (_currentSegment != null && span.TryCopyTo(_currentSegment.AsSpan(_position)))
+            {
+                _position += span.Length;
+                _bytesWritten += span.Length;
+            }
+            else
+            {
+                BuffersExtensions.Write(this, span);
+            }
+        }
+#endif
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Reset();
+            }
+        }
+
+        /// <summary>
+        /// Holds a byte[] from the pool and a size value. Basically a Memory but guaranteed to be backed by an ArrayPool byte[], so that we know we can return it.
+        /// </summary>
+        private readonly struct CompletedBuffer
+        {
+            public byte[] Buffer { get; }
+            public int Length { get; }
+
+            public ReadOnlySpan<byte> Span => Buffer.AsSpan(0, Length);
+
+            public CompletedBuffer(byte[] buffer, int length)
+            {
+                Buffer = buffer;
+                Length = length;
+            }
+
+            public void Return()
+            {
+                ArrayPool<byte>.Shared.Return(Buffer);
+            }
+        }
+    }
+}

--- a/Source/MQTTnet/Serializer/MqttPacketSerializer.cs
+++ b/Source/MQTTnet/Serializer/MqttPacketSerializer.cs
@@ -362,12 +362,12 @@ namespace MQTTnet.Serializer
             if (ProtocolVersion == MqttProtocolVersion.V311)
             {
                 packetWriter.WriteWithLengthPrefix("MQTT");
-                packetWriter.Write(4); // 3.1.2.2 Protocol Level 4
+                packetWriter.WriteByte(4); // 3.1.2.2 Protocol Level 4
             }
             else
             {
                 packetWriter.WriteWithLengthPrefix("MQIsdp");
-                packetWriter.Write(3); // Protocol Level 3
+                packetWriter.WriteByte(3); // Protocol Level 3
             }
 
             byte connectFlags = 0x0;
@@ -402,8 +402,8 @@ namespace MQTTnet.Serializer
                 connectFlags |= 0x80;
             }
             
-            packetWriter.Write(connectFlags);
-            packetWriter.Write(packet.KeepAlivePeriod);
+            packetWriter.WriteByte(connectFlags);
+            packetWriter.WriteUInt16(packet.KeepAlivePeriod);
             packetWriter.WriteWithLengthPrefix(packet.ClientId);
 
             if (packet.WillMessage != null)
@@ -429,7 +429,7 @@ namespace MQTTnet.Serializer
         {
             if (ProtocolVersion == MqttProtocolVersion.V310)
             {
-                packetWriter.Write(0);
+                packetWriter.WriteByte(0);
             }
             else if (ProtocolVersion == MqttProtocolVersion.V311)
             {
@@ -439,14 +439,14 @@ namespace MQTTnet.Serializer
                     connectAcknowledgeFlags |= 0x1;
                 }
                 
-                packetWriter.Write(connectAcknowledgeFlags);
+                packetWriter.WriteByte(connectAcknowledgeFlags);
             }
             else
             {
                 throw new MqttProtocolViolationException("Protocol version not supported.");
             }
 
-            packetWriter.Write((byte)packet.ConnectReturnCode);
+            packetWriter.WriteByte((byte)packet.ConnectReturnCode);
 
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.ConnAck);
         }
@@ -458,7 +458,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("PubRel packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubRel, 0x02);
         }
@@ -476,7 +476,7 @@ namespace MQTTnet.Serializer
                     throw new MqttProtocolViolationException("Publish packet has no packet identifier.");
                 }
 
-                packetWriter.Write(packet.PacketIdentifier.Value);
+                packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
             }
             else
             {
@@ -515,7 +515,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("PubAck packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubAck);
         }
@@ -527,7 +527,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("PubRec packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubRec);
         }
@@ -539,7 +539,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("PubComp packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubComp);
         }
@@ -553,14 +553,14 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("Subscribe packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             if (packet.TopicFilters?.Count > 0)
             {
                 foreach (var topicFilter in packet.TopicFilters)
                 {
                     packetWriter.WriteWithLengthPrefix(topicFilter.Topic);
-                    packetWriter.Write((byte)topicFilter.QualityOfServiceLevel);
+                    packetWriter.WriteByte((byte)topicFilter.QualityOfServiceLevel);
                 }
             }
 
@@ -574,13 +574,13 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("SubAck packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             if (packet.SubscribeReturnCodes?.Any() == true)
             {
                 foreach (var packetSubscribeReturnCode in packet.SubscribeReturnCodes)
                 {
-                    packetWriter.Write((byte)packetSubscribeReturnCode);
+                    packetWriter.WriteByte((byte)packetSubscribeReturnCode);
                 }
             }
 
@@ -596,7 +596,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("Unsubscribe packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
 
             if (packet.TopicFilters?.Any() == true)
             {
@@ -616,7 +616,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException("UnsubAck packet has no packet identifier.");
             }
 
-            packetWriter.Write(packet.PacketIdentifier.Value);
+            packetWriter.WriteUInt16(packet.PacketIdentifier.Value);
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.UnsubAck);
         }
 

--- a/Source/MQTTnet/Serializer/MqttPacketSerializer.cs
+++ b/Source/MQTTnet/Serializer/MqttPacketSerializer.cs
@@ -13,33 +13,33 @@ namespace MQTTnet.Serializer
 
         public MqttProtocolVersion ProtocolVersion { get; set; } = MqttProtocolVersion.V311;
 
-        public ArraySegment<byte> Serialize(MqttBasePacket packet)
+        public byte[] Serialize(MqttBasePacket packet)
         {
             if (packet == null) throw new ArgumentNullException(nameof(packet));
 
-            var packetWriter = new MqttPacketWriter();
+            var stream = MemoryBufferWriter.Get();
+            
+            try
+            {
+                var fixedHeader = SerializePacket(packet, stream);
+                var bodyLength = (int)stream.Length;
+                var headerLength = MqttPacketWriter.GetHeaderLength(bodyLength);
+                
+                var result = new byte[headerLength + bodyLength];
+                result[0] = fixedHeader;
+                MqttPacketWriter.WriteBodyLength(bodyLength, result);
 
-            // Leave enough head space for max header size (fixed + 4 variable remaining length = 5 bytes)
-            packetWriter.Seek(5);
+                stream.CopyTo(result.AsSpan(headerLength));
 
-            var fixedHeader = SerializePacket(packet, packetWriter);
-            var remainingLength = packetWriter.Length - 5;
-
-            var remainingLengthBuffer = MqttPacketWriter.EncodeRemainingLength(remainingLength);
-
-            var headerSize = FixedHeaderSize + remainingLengthBuffer.Count;
-            var headerOffset = 5 - headerSize;
-
-            // Position cursor on correct offset on beginining of array (has leading 0x0)
-            packetWriter.Seek(headerOffset);
-            packetWriter.Write(fixedHeader);
-            packetWriter.Write(remainingLengthBuffer.Array, remainingLengthBuffer.Offset, remainingLengthBuffer.Count);
-
-            var buffer = packetWriter.GetBuffer();
-            return new ArraySegment<byte>(buffer, headerOffset, packetWriter.Length - headerOffset);
+                return result;
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(stream);
+            }
         }
 
-        private byte SerializePacket(MqttBasePacket packet, MqttPacketWriter packetWriter)
+        private byte SerializePacket(MqttBasePacket packet, MemoryBufferWriter packetWriter)
         {
             switch (packet)
             {
@@ -73,106 +73,134 @@ namespace MQTTnet.Serializer
 
             switch ((MqttControlPacketType)controlPacketType)
             {
-                case MqttControlPacketType.Connect: return DeserializeConnect(receivedMqttPacket.Body);
-                case MqttControlPacketType.ConnAck: return DeserializeConnAck(receivedMqttPacket.Body);
+                case MqttControlPacketType.Connect: return DeserializeConnect(receivedMqttPacket.Body.Span);
+                case MqttControlPacketType.ConnAck: return DeserializeConnAck(receivedMqttPacket.Body.Span);
                 case MqttControlPacketType.Disconnect: return new MqttDisconnectPacket();
                 case MqttControlPacketType.Publish: return DeserializePublish(receivedMqttPacket);
-                case MqttControlPacketType.PubAck: return DeserializePubAck(receivedMqttPacket.Body);
-                case MqttControlPacketType.PubRec: return DeserializePubRec(receivedMqttPacket.Body);
-                case MqttControlPacketType.PubRel: return DeserializePubRel(receivedMqttPacket.Body);
-                case MqttControlPacketType.PubComp: return DeserializePubComp(receivedMqttPacket.Body);
+                case MqttControlPacketType.PubAck: return DeserializePubAck(receivedMqttPacket.Body.Span);
+                case MqttControlPacketType.PubRec: return DeserializePubRec(receivedMqttPacket.Body.Span);
+                case MqttControlPacketType.PubRel: return DeserializePubRel(receivedMqttPacket.Body.Span);
+                case MqttControlPacketType.PubComp: return DeserializePubComp(receivedMqttPacket.Body.Span);
                 case MqttControlPacketType.PingReq: return new MqttPingReqPacket();
                 case MqttControlPacketType.PingResp: return new MqttPingRespPacket();
-                case MqttControlPacketType.Subscribe: return DeserializeSubscribe(receivedMqttPacket.Body);
-                case MqttControlPacketType.SubAck: return DeserializeSubAck(receivedMqttPacket.Body);
-                case MqttControlPacketType.Unsubscibe: return DeserializeUnsubscribe(receivedMqttPacket.Body);
-                case MqttControlPacketType.UnsubAck: return DeserializeUnsubAck(receivedMqttPacket.Body);
+                case MqttControlPacketType.Subscribe: return DeserializeSubscribe(receivedMqttPacket);
+                case MqttControlPacketType.SubAck: return DeserializeSubAck(receivedMqttPacket);
+                case MqttControlPacketType.Unsubscibe: return DeserializeUnsubscribe(receivedMqttPacket);
+                case MqttControlPacketType.UnsubAck: return DeserializeUnsubAck(receivedMqttPacket.Body.Span);
 
                 default: throw new MqttProtocolViolationException($"Packet type ({controlPacketType}) not supported.");
             }
         }
 
-        private static MqttBasePacket DeserializeUnsubAck(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializeUnsubAck(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
 
+            var remainingData = input;
             return new MqttUnsubAckPacket
             {
-                PacketIdentifier = body.ReadUInt16()
+                PacketIdentifier = remainingData.ReadUInt16()
             };
         }
 
-        private static MqttBasePacket DeserializePubComp(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializePubComp(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
 
+            var remainingData = input;
             return new MqttPubCompPacket
             {
-                PacketIdentifier = body.ReadUInt16()
+                PacketIdentifier = remainingData.ReadUInt16()
             };
         }
 
-        private static MqttBasePacket DeserializePubRel(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializePubRel(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
 
+            var remainingData = input;
             return new MqttPubRelPacket
             {
-                PacketIdentifier = body.ReadUInt16()
+                PacketIdentifier = remainingData.ReadUInt16()
             };
         }
 
-        private static MqttBasePacket DeserializePubRec(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializePubRec(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
 
+            var remainingData = input;
             return new MqttPubRecPacket
             {
-                PacketIdentifier = body.ReadUInt16()
+                PacketIdentifier = remainingData.ReadUInt16()
             };
         }
 
-        private static MqttBasePacket DeserializePubAck(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializePubAck(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
 
+            var remainingData = input;
             return new MqttPubAckPacket
             {
-                PacketIdentifier = body.ReadUInt16()
+                PacketIdentifier = remainingData.ReadUInt16()
             };
         }
 
-        private static MqttBasePacket DeserializeUnsubscribe(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializeUnsubscribe(ReceivedMqttPacket receivedMqttPacket)
         {
+            ReadOnlySpan<byte> body = receivedMqttPacket.Body.Span;
             ThrowIfBodyIsEmpty(body);
 
+            var remainingData = body;
             var packet = new MqttUnsubscribePacket
             {
-                PacketIdentifier = body.ReadUInt16(),
+                PacketIdentifier = remainingData.ReadUInt16(),
             };
 
-            while (!body.EndOfStream)
+            while (remainingData.Length > 0)
             {
-                packet.TopicFilters.Add(body.ReadStringWithLengthPrefix());
+                packet.TopicFilters.Add(remainingData.ReadStringWithLengthPrefix());
             }
 
             return packet;
         }
 
-        private static MqttBasePacket DeserializeSubscribe(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializeSubscribe(ReceivedMqttPacket receivedMqttPacket)
         {
+            ReadOnlySpan<byte> body = receivedMqttPacket.Body.Span;
             ThrowIfBodyIsEmpty(body);
 
+            var remainingData = body;
             var packet = new MqttSubscribePacket
             {
-                PacketIdentifier = body.ReadUInt16()
+                PacketIdentifier = remainingData.ReadUInt16()
             };
 
-            while (!body.EndOfStream)
+            while (remainingData.Length > 0)
             {
                 packet.TopicFilters.Add(new TopicFilter(
-                    body.ReadStringWithLengthPrefix(),
-                    (MqttQualityOfServiceLevel)body.ReadByte()));
+                    remainingData.ReadStringWithLengthPrefix(),
+                    (MqttQualityOfServiceLevel)remainingData.ReadByte()));
+            }
+
+            return packet;
+        }
+
+        private static MqttBasePacket DeserializeSubAck(ReceivedMqttPacket receivedMqttPacket)
+        {
+            ReadOnlySpan<byte> body = receivedMqttPacket.Body.Span;
+            ThrowIfBodyIsEmpty(body);
+
+            var remainingData = body;
+            var packet = new MqttSubAckPacket
+            {
+                PacketIdentifier = remainingData.ReadUInt16()
+            };
+
+            while (remainingData.Length > 0)
+            {
+                packet.SubscribeReturnCodes.Add((MqttSubscribeReturnCode)remainingData.ReadByte());
             }
 
             return packet;
@@ -180,19 +208,20 @@ namespace MQTTnet.Serializer
 
         private static MqttBasePacket DeserializePublish(ReceivedMqttPacket receivedMqttPacket)
         {
-            var body = receivedMqttPacket.Body;
+            ReadOnlySpan<byte> body = receivedMqttPacket.Body.Span;
             ThrowIfBodyIsEmpty(body);
 
+            var remainingData = body;
             var retain = (receivedMqttPacket.FixedHeader & 0x1) > 0;
             var qualityOfServiceLevel = (MqttQualityOfServiceLevel)(receivedMqttPacket.FixedHeader >> 1 & 0x3);
             var dup = (receivedMqttPacket.FixedHeader & 0x3) > 0;
 
-            var topic = body.ReadStringWithLengthPrefix();
+            var topic = remainingData.ReadStringWithLengthPrefix();
 
             ushort? packetIdentifier = null;
             if (qualityOfServiceLevel > MqttQualityOfServiceLevel.AtMostOnce)
             {
-                packetIdentifier = body.ReadUInt16();
+                packetIdentifier = remainingData.ReadUInt16();
             }
 
             var packet = new MqttPublishPacket
@@ -200,7 +229,7 @@ namespace MQTTnet.Serializer
                 PacketIdentifier = packetIdentifier,
                 Retain = retain,
                 Topic = topic,
-                Payload = body.ReadRemainingData().ToArray(),
+                Payload = remainingData.ToArray(),
                 QualityOfServiceLevel = qualityOfServiceLevel,
                 Dup = dup
             };
@@ -208,16 +237,17 @@ namespace MQTTnet.Serializer
             return packet;
         }
 
-        private static MqttBasePacket DeserializeConnect(MqttPacketBodyReader body)
+        private static MqttBasePacket DeserializeConnect(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
+            var remainingData = input;
 
-            var protocolName = body.ReadStringWithLengthPrefix();
+            var protocolName = remainingData.ReadStringWithLengthPrefix();
 
             MqttProtocolVersion protocolVersion;
             if (protocolName == "MQTT")
             {
-                var protocolLevel = body.ReadByte();
+                var protocolLevel = remainingData.ReadByte();
                 if (protocolLevel != 4)
                 {
                     throw new MqttProtocolViolationException($"Protocol level ({protocolLevel}) not supported for MQTT 3.1.1.");
@@ -227,7 +257,7 @@ namespace MQTTnet.Serializer
             }
             else if (protocolName == "MQIsdp")
             {
-                var protocolLevel = body.ReadByte();
+                var protocolLevel = remainingData.ReadByte();
                 if (protocolLevel != 3)
                 {
                     throw new MqttProtocolViolationException($"Protocol level ({protocolLevel}) not supported for MQTT 3.1.");
@@ -240,7 +270,7 @@ namespace MQTTnet.Serializer
                 throw new MqttProtocolViolationException($"Protocol name ({protocolName}) is not supported.");
             }
 
-            var connectFlags = body.ReadByte();
+            var connectFlags = remainingData.ReadByte();
             if ((connectFlags & 0x1) > 0)
             {
                 throw new MqttProtocolViolationException("The first bit of the Connect Flags must be set to 0.");
@@ -258,15 +288,15 @@ namespace MQTTnet.Serializer
             var passwordFlag = (connectFlags & 0x40) > 0;
             var usernameFlag = (connectFlags & 0x80) > 0;
 
-            packet.KeepAlivePeriod = body.ReadUInt16();
-            packet.ClientId = body.ReadStringWithLengthPrefix();
+            packet.KeepAlivePeriod = remainingData.ReadUInt16();
+            packet.ClientId = remainingData.ReadStringWithLengthPrefix();
 
             if (willFlag)
             {
                 packet.WillMessage = new MqttApplicationMessage
                 {
-                    Topic = body.ReadStringWithLengthPrefix(),
-                    Payload = body.ReadWithLengthPrefix().ToArray(),
+                    Topic = remainingData.ReadStringWithLengthPrefix(),
+                    Payload = remainingData.ReadWithLengthPrefix(),
                     QualityOfServiceLevel = (MqttQualityOfServiceLevel)willQoS,
                     Retain = willRetain
                 };
@@ -274,49 +304,33 @@ namespace MQTTnet.Serializer
 
             if (usernameFlag)
             {
-                packet.Username = body.ReadStringWithLengthPrefix();
+                packet.Username = remainingData.ReadStringWithLengthPrefix();
             }
 
             if (passwordFlag)
             {
-                packet.Password = body.ReadStringWithLengthPrefix();
+                packet.Password = remainingData.ReadStringWithLengthPrefix();
             }
 
             ValidateConnectPacket(packet);
             return packet;
         }
 
-        private static MqttBasePacket DeserializeSubAck(MqttPacketBodyReader body)
+        private MqttBasePacket DeserializeConnAck(in ReadOnlySpan<byte> input)
         {
-            ThrowIfBodyIsEmpty(body);
+            ThrowIfBodyIsEmpty(input);
 
-            var packet = new MqttSubAckPacket
-            {
-                PacketIdentifier = body.ReadUInt16()
-            };
-
-            while (!body.EndOfStream)
-            {
-                packet.SubscribeReturnCodes.Add((MqttSubscribeReturnCode)body.ReadByte());
-            }
-
-            return packet;
-        }
-
-        private MqttBasePacket DeserializeConnAck(MqttPacketBodyReader body)
-        {
-            ThrowIfBodyIsEmpty(body);
-
+            var remainingData = input;
             var packet = new MqttConnAckPacket();
 
-            var acknowledgeFlags = body.ReadByte();
+            var acknowledgeFlags = remainingData.ReadByte();
             
             if (ProtocolVersion == MqttProtocolVersion.V311)
             {
                 packet.IsSessionPresent = (acknowledgeFlags & 0x1) > 0;
             }
 
-            packet.ConnectReturnCode = (MqttConnectReturnCode)body.ReadByte();
+            packet.ConnectReturnCode = (MqttConnectReturnCode)remainingData.ReadByte();
 
             return packet;
         }
@@ -340,7 +354,7 @@ namespace MQTTnet.Serializer
             }
         }
 
-        private byte Serialize(MqttConnectPacket packet, MqttPacketWriter packetWriter)
+        private byte Serialize(MqttConnectPacket packet, MemoryBufferWriter packetWriter)
         {
             ValidateConnectPacket(packet);
 
@@ -411,7 +425,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.Connect);
         }
 
-        private byte Serialize(MqttConnAckPacket packet, MqttPacketWriter packetWriter)
+        private byte Serialize(MqttConnAckPacket packet, MemoryBufferWriter packetWriter)
         {
             if (ProtocolVersion == MqttProtocolVersion.V310)
             {
@@ -437,7 +451,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.ConnAck);
         }
 
-        private static byte Serialize(MqttPubRelPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttPubRelPacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.PacketIdentifier.HasValue)
             {
@@ -449,7 +463,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubRel, 0x02);
         }
 
-        private static byte Serialize(MqttPublishPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttPublishPacket packet, MemoryBufferWriter packetWriter)
         {
             ValidatePublishPacket(packet);
 
@@ -494,7 +508,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.Publish, fixedHeader);
         }
 
-        private static byte Serialize(MqttPubAckPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttPubAckPacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.PacketIdentifier.HasValue)
             {
@@ -506,7 +520,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubAck);
         }
 
-        private static byte Serialize(MqttPubRecPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttPubRecPacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.PacketIdentifier.HasValue)
             {
@@ -518,7 +532,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubRec);
         }
 
-        private static byte Serialize(MqttPubCompPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttPubCompPacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.PacketIdentifier.HasValue)
             {
@@ -530,7 +544,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.PubComp);
         }
 
-        private static byte Serialize(MqttSubscribePacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttSubscribePacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.TopicFilters.Any()) throw new MqttProtocolViolationException("At least one topic filter must be set [MQTT-3.8.3-3].");
 
@@ -553,7 +567,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.Subscribe, 0x02);
         }
 
-        private static byte Serialize(MqttSubAckPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttSubAckPacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.PacketIdentifier.HasValue)
             {
@@ -573,7 +587,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.SubAck);
         }
 
-        private static byte Serialize(MqttUnsubscribePacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttUnsubscribePacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.TopicFilters.Any()) throw new MqttProtocolViolationException("At least one topic filter must be set [MQTT-3.10.3-2].");
 
@@ -595,7 +609,7 @@ namespace MQTTnet.Serializer
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.Unsubscibe, 0x02);
         }
 
-        private static byte Serialize(MqttUnsubAckPacket packet, MqttPacketWriter packetWriter)
+        private static byte Serialize(MqttUnsubAckPacket packet, MemoryBufferWriter packetWriter)
         {
             if (!packet.PacketIdentifier.HasValue)
             {
@@ -612,9 +626,9 @@ namespace MQTTnet.Serializer
         }
 
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
-        private static void ThrowIfBodyIsEmpty(MqttPacketBodyReader body)
+        private static void ThrowIfBodyIsEmpty(in ReadOnlySpan<byte> input)
         {
-            if (body == null || body.Length == 0)
+            if (input == null || input.Length == 0)
             {
                 throw new MqttProtocolViolationException("Data from the body is required but not present.");
             }

--- a/Source/MQTTnet/Serializer/MqttPacketWriter.cs
+++ b/Source/MQTTnet/Serializer/MqttPacketWriter.cs
@@ -15,7 +15,7 @@ namespace MQTTnet.Serializer
             return (byte)fixedHeader;
         }
 
-        public static void Write(this MemoryBufferWriter stream, ushort value)
+        public static void WriteUInt16(this MemoryBufferWriter stream, ushort value)
         {
             System.Buffers.Binary.BinaryPrimitives.WriteUInt16BigEndian(stream.GetSpan(), value);
             stream.Advance(2);
@@ -35,7 +35,7 @@ namespace MQTTnet.Serializer
         {
             var length = (ushort)value.Length;
 
-            stream.Write(length);
+            stream.WriteUInt16(length);
             stream.Write(value, 0, length);
         }
 

--- a/Tests/MQTTnet.Benchmarks/ChannelAdapterBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/ChannelAdapterBenchmark.cs
@@ -27,7 +27,7 @@ namespace MQTTnet.Benchmarks
 
             _packet = message.ToPublishPacket();
             var serializer = new MqttPacketSerializer();
-            var serializedPacket = Join(serializer.Serialize(_packet));
+            var serializedPacket = serializer.Serialize(_packet);
 
             _iterations = 10000;
 
@@ -69,17 +69,6 @@ namespace MQTTnet.Benchmarks
             }
 
             _stream.Position = 0;
-        }
-
-        private static byte[] Join(params ArraySegment<byte>[] chunks)
-        {
-            var buffer = new MemoryStream();
-            foreach (var chunk in chunks)
-            {
-                buffer.Write(chunk.Array, chunk.Offset, chunk.Count);
-            }
-
-            return buffer.ToArray();
         }
     }
 }

--- a/Tests/MQTTnet.Benchmarks/MessageProcessingBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/MessageProcessingBenchmark.cs
@@ -9,6 +9,7 @@ namespace MQTTnet.Benchmarks
 {
     [ClrJob]
     [RPlotExporter, RankColumn]
+    [MemoryDiagnoser]
     public class MessageProcessingBenchmark
     {
         private IMqttServer _mqttServer;

--- a/Tests/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -17,8 +17,11 @@ namespace MQTTnet.Benchmarks
     public class SerializerBenchmark
     {
         private MqttBasePacket _packet;
-        private ArraySegment<byte> _serializedPacket;
+        private byte[] _serializedPacket;
         private MqttPacketSerializer _serializer;
+
+        [Params(10000)]
+        public int Iterations { get; set; }
 
         [GlobalSetup]
         public void Setup()
@@ -35,7 +38,7 @@ namespace MQTTnet.Benchmarks
         [Benchmark]
         public void Serialize_10000_Messages()
         {
-            for (var i = 0; i < 10000; i++)
+            for (var i = 0; i < Iterations; i++)
             {
                 _serializer.Serialize(_packet);
             }
@@ -44,31 +47,17 @@ namespace MQTTnet.Benchmarks
         [Benchmark]
         public void Deserialize_10000_Messages()
         {
-            for (var i = 0; i < 10000; i++)
+            for (var i = 0; i < Iterations; i++)
             {
-                using (var headerStream = new MemoryStream(Join(_serializedPacket)))
+                using (var headerStream = new MemoryStream(_serializedPacket))
                 {
                     var channel = new TestMqttChannel(headerStream);
 
                     var header = MqttPacketReader.ReadFixedHeaderAsync(channel, CancellationToken.None).GetAwaiter().GetResult();
-                    
-                    using (var bodyStream = new MemoryStream(Join(_serializedPacket), (int)headerStream.Position, header.RemainingLength))
-                    {
-                        _serializer.Deserialize(new ReceivedMqttPacket(header.Flags, new MqttPacketBodyReader(bodyStream.ToArray())));
-                    }
+                    var packet = new ReceivedMqttPacket(header.Flags, _serializedPacket.AsMemory((int)headerStream.Position, header.RemainingLength));
+                    _serializer.Deserialize(packet);
                 }
             }
-        }
-        
-        private static byte[] Join(params ArraySegment<byte>[] chunks)
-        {
-            var buffer = new MemoryStream();
-            foreach (var chunk in chunks)
-            {
-                buffer.Write(chunk.Array, chunk.Offset, chunk.Count);
-            }
-
-            return buffer.ToArray();
         }
     }
 }


### PR DESCRIPTION
before:

|                      Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
| --------------------------- |---------:|----------:|----------:|----------:|----------:|
|    Serialize_10000_Messages | 2.496 ms | 0.0463 ms | 0.0410 ms |  781.2500 |   3.13 MB |
|  Deserialize_10000_Messages | 7.791 ms | 0.0842 ms | 0.0746 ms | 3765.6250 |  15.11 MB |

after:

|                      Method |      Mean |     Error |    StdDev |     Gen 0 |  Allocated |
| --------------------------- |---------:|----------:|----------:|----------:|-----------:|
|    Serialize_10000_Messages |     2.830 ms | 0.0558 ms | 0.0597 ms |  152.3438 |  625.01 KB |
|  Deserialize_10000_Messages |      5.313 ms | 0.0790 ms | 0.0739 ms | 1218.7500 | 5000.15 KB |

we can argue about serializer performance as it is 10% slower now but I guess the memory pooling should be worth it especially for bigger messages. anyway let me know what u think about this.

there is still some potential in string encoding MqttPacketWriter.cs line 33 - 35 but that will have to wait until the package is final.

preview with that  change:

|                      Method |     Mean |     Error |    StdDev |     Gen 0 |  Allocated |
| --------------------------- |---------:|----------:|----------:|----------:|-----------:|
|    Serialize_10000_Messages | 2.613 ms | 0.0507 ms | 0.0623 ms |   74.2188 |   312.5 KB |
|  Deserialize_10000_Messages | 5.488 ms | 0.1090 ms | 0.1455 ms | 1218.7500 | 5000.15 KB |

the header deserialization can also be improved if we use new connection abstractions (see issue #250 )

