### PR TITLE
Fix for incoming SSL connections

### DIFF
--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -70,15 +70,17 @@ namespace MQTTnet.Implementations
 #endif
                     clientSocket.NoDelay = true;
 
+                    SslStream sslStream = null;
+
                     if (_tlsCertificate != null)
                     {
-                        var sslStream = new SslStream(new NetworkStream(clientSocket), false);
+                        sslStream = new SslStream(new NetworkStream(clientSocket), false);
                         await sslStream.AuthenticateAsServerAsync(_tlsCertificate, false, SslProtocols.Tls12, false).ConfigureAwait(false);
                     }
 
                     _logger.Verbose($"Client '{clientSocket.RemoteEndPoint}' accepted by TCP listener '{_socket.LocalEndPoint}, {_addressFamily}'.");
 
-                    var clientAdapter = new MqttChannelAdapter(new MqttTcpChannel(clientSocket, null), new MqttPacketSerializer(), _logger);
+                    var clientAdapter = new MqttChannelAdapter(new MqttTcpChannel(clientSocket, sslStream), new MqttPacketSerializer(), _logger);
                     ClientAccepted?.Invoke(this, new MqttServerAdapterClientAcceptedEventArgs(clientAdapter));
                 }
                 catch (ObjectDisposedException)


### PR DESCRIPTION
Fix a bug where an incoming SSL client connection was being treated plain-text connection.  SSL stream was being correctly created and authenticated, but not passed to the channel constructor.