### PR TITLE
Prevent unsubscription overtaking later subscription

### DIFF
--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -306,14 +306,14 @@ namespace MQTTnet.Extensions.ManagedClient
 
             try
             {
-                if (subscriptions.Any())
-                {
-                    await _mqttClient.SubscribeAsync(subscriptions).ConfigureAwait(false);
-                }
-
                 if (unsubscriptions.Any())
                 {
                     await _mqttClient.UnsubscribeAsync(unsubscriptions).ConfigureAwait(false);
+                }
+
+                if (subscriptions.Any())
+                {
+                    await _mqttClient.SubscribeAsync(subscriptions).ConfigureAwait(false);
                 }
             }
             catch (Exception exception)


### PR DESCRIPTION
With the ManagedMqttClient, when unsubscribing and again subscribing to a topic within the same ConnectionCheckInterval, the unsubscription is erroneously performed after the subscription, leaving the topic unsubscribed. 

The following code will leave the topic unsubscribed on MqttClient (even though it's still in the ManagedMqttClient's dictionary of subscriptions), i.e. you won't receive messages on topic x.

```
client.SubscribeAsync(new TopicFilter("x", MqttQualityOfServiceLevel.ExactlyOnce));
client.UnsubscribeAsync("x");
client.SubscribeAsync(new TopicFilter("x", MqttQualityOfServiceLevel.ExactlyOnce));
```

This is because both the subscription and the unsubscription are put in their respective queues. When the queues are forwarded to the MqttClient, first the subscriptions are performed on the underlying MqttClient, and then the unsubscriptions are performed. Thus, even though the subscription was performed later, the unsubscription is done afterwards. (the other way round isn't a problem, because UnsubscribeAsync removes a pending subscription on the topic)

This changeset fixes this problem by simply performing the unsubscriptions first.