### PR TITLE
Add server support for client certificate

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Connections;
+﻿using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
 using MQTTnet.Adapter;
 using MQTTnet.AspNetCore.Client.Tcp;
 using MQTTnet.Exceptions;
@@ -26,6 +28,16 @@ namespace MQTTnet.AspNetCore
         public IMqttPacketSerializer PacketSerializer { get; }
         public event EventHandler ReadingPacketStarted;
         public event EventHandler ReadingPacketCompleted;
+
+        public X509Certificate RemoteCertificate {
+            get {
+                var tlsFeature = Connection.Features.Get<ITlsConnectionFeature>();
+                if (tlsFeature != null) {
+                    return tlsFeature.ClientCertificate;
+                }
+                return null;
+            }
+        }
 
         public Task ConnectAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {

--- a/Source/MQTTnet/Adapter/IMqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/IMqttChannelAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using MQTTnet.Packets;
@@ -9,6 +10,8 @@ namespace MQTTnet.Adapter
     public interface IMqttChannelAdapter : IDisposable
     {
         string Endpoint { get; }
+
+        X509Certificate RemoteCertificate { get; }
 
         IMqttPacketSerializer PacketSerializer { get; }
 

--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using MQTTnet.Channel;
@@ -40,6 +41,8 @@ namespace MQTTnet.Adapter
         }
 
         public string Endpoint => _channel.Endpoint;
+
+        public X509Certificate RemoteCertificate => _channel.RemoteCertificate;
 
         public IMqttPacketSerializer PacketSerializer { get; }
 

--- a/Source/MQTTnet/Channel/IMqttChannel.cs
+++ b/Source/MQTTnet/Channel/IMqttChannel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,6 +8,8 @@ namespace MQTTnet.Channel
     public interface IMqttChannel : IDisposable
     {
         string Endpoint { get; }
+
+        X509Certificate RemoteCertificate { get; }
 
         Task ConnectAsync(CancellationToken cancellationToken);
         Task DisconnectAsync();

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.Uwp.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.Uwp.cs
@@ -53,6 +53,8 @@ namespace MQTTnet.Implementations
             }
         }
 
+        public X509Certificate RemoteCertificate => null;
+
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
             if (_socket == null)

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -29,6 +29,8 @@ namespace MQTTnet.Implementations
 
         public string Endpoint { get; }
 
+        public X509Certificate RemoteCertificate => null;
+
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
             var uri = _options.Uri;
@@ -108,7 +110,7 @@ namespace MQTTnet.Implementations
 
         public async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            // This lock is required because the client will throw an exception if _SendAsync_ is 
+            // This lock is required because the client will throw an exception if _SendAsync_ is
             // called from multiple threads at the same time. But this issue only happens with several
             // framework versions.
             await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/Source/MQTTnet/Internal/TestMqttChannel.cs
+++ b/Source/MQTTnet/Internal/TestMqttChannel.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using MQTTnet.Channel;
@@ -15,6 +16,8 @@ namespace MQTTnet.Internal
         }
 
         public string Endpoint { get; } = "<Test channel>";
+
+        public X509Certificate RemoteCertificate => null;
 
         public Task ConnectAsync(CancellationToken cancellationToken)
         {

--- a/Source/MQTTnet/Server/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/MqttClientSessionsManager.cs
@@ -208,7 +208,7 @@ namespace MQTTnet.Server
         private async Task RunSession(IMqttChannelAdapter clientAdapter, CancellationToken cancellationToken)
         {
             var clientId = string.Empty;
-            
+
             try
             {
                 var firstPacket = await clientAdapter.ReceivePacketAsync(_options.DefaultCommunicationTimeout, cancellationToken).ConfigureAwait(false);
@@ -280,6 +280,7 @@ namespace MQTTnet.Server
 
             var context = new MqttConnectionValidatorContext(
                 connectPacket.ClientId,
+                clientAdapter.RemoteCertificate,
                 connectPacket.Username,
                 connectPacket.Password,
                 connectPacket.WillMessage,

--- a/Source/MQTTnet/Server/MqttConnectionValidatorContext.cs
+++ b/Source/MQTTnet/Server/MqttConnectionValidatorContext.cs
@@ -1,12 +1,14 @@
-﻿using MQTTnet.Protocol;
+﻿using System.Security.Cryptography.X509Certificates;
+using MQTTnet.Protocol;
 
 namespace MQTTnet.Server
 {
     public class MqttConnectionValidatorContext
     {
-        public MqttConnectionValidatorContext(string clientId, string username, string password, MqttApplicationMessage willMessage, string endpoint)
+        public MqttConnectionValidatorContext(string clientId, X509Certificate clientCertificate, string username, string password, MqttApplicationMessage willMessage, string endpoint)
         {
             ClientId = clientId;
+            ClientCertificate = clientCertificate;
             Username = username;
             Password = password;
             WillMessage = willMessage;
@@ -14,6 +16,8 @@ namespace MQTTnet.Server
         }
 
         public string ClientId { get; }
+
+        public X509Certificate ClientCertificate { get; }
 
         public string Username { get; }
 

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Net;
+using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Server
 {
@@ -56,7 +58,7 @@ namespace MQTTnet.Server
             _options.DefaultEndpointOptions.IsEnabled = false;
             return this;
         }
-        
+
         public MqttServerOptionsBuilder WithEncryptedEndpoint()
         {
             _options.TlsEndpointOptions.IsEnabled = true;
@@ -87,12 +89,18 @@ namespace MQTTnet.Server
             return this;
         }
 
+        public MqttServerOptionsBuilder WithClientTlsParameters(MqttServerOptionsBuilderClientTlsParameters parameters)
+        {
+            _options.TlsEndpointOptions.ClientTlsParameters = parameters;
+            return this;
+        }
+
         public MqttServerOptionsBuilder WithoutEncryptedEndpoint()
         {
             _options.TlsEndpointOptions.IsEnabled = false;
             return this;
         }
-        
+
         public MqttServerOptionsBuilder WithStorage(IMqttServerStorage value)
         {
             _options.Storage = value;

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilderClientTlsParameters.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilderClientTlsParameters.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MQTTnet.Server
+{
+    public class MqttServerOptionsBuilderClientTlsParameters
+    {
+        public bool ClientCertificateRequired { get; set; }
+
+        public Func<X509Certificate, X509Chain, SslPolicyErrors, bool> ClientCertificateValidationCallback
+        {
+            get;
+            set;
+        }
+
+        public bool AllowUntrustedCertificates { get; set; }
+
+        public bool IgnoreCertificateChainErrors { get; set; }
+
+        public bool IgnoreCertificateRevocationErrors { get; set; }
+    }
+}

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Security.Authentication;
+﻿using System;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Server
 {
@@ -11,7 +14,8 @@ namespace MQTTnet.Server
 
         public byte[] Certificate { get; set; }
 
-
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
+
+        public MqttServerOptionsBuilderClientTlsParameters ClientTlsParameters  { get; set; } = new MqttServerOptionsBuilderClientTlsParameters();
     }
 }

--- a/Tests/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MQTTnet.Adapter;
 using MQTTnet.Channel;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Benchmarks
 {
@@ -76,6 +77,8 @@ namespace MQTTnet.Benchmarks
             }
 
             public string Endpoint { get; }
+
+            public X509Certificate RemoteCertificate => null;
 
             public void Reset()
             {

--- a/Tests/MQTTnet.Core.Tests/TestMqttCommunicationAdapter.cs
+++ b/Tests/MQTTnet.Core.Tests/TestMqttCommunicationAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using MQTTnet.Adapter;
@@ -17,6 +18,8 @@ namespace MQTTnet.Core.Tests
         public string Endpoint { get; }
 
         public IMqttPacketSerializer PacketSerializer { get; } = new MqttPacketSerializer();
+
+        public X509Certificate RemoteCertificate => null;
 
         public event EventHandler ReadingPacketStarted;
         public event EventHandler ReadingPacketCompleted;


### PR DESCRIPTION
This introduces a new set of server configuration parameters needed to
validate and propagate to the MqttConnectionValidatorContext the X509
certificate that can be used by a client to authenticate the connection
(and itself if the server is correctly configured or appropriate
validation code is provided).