### PR TITLE
Patch 1

### DIFF
--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -16,10 +16,10 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.5-rc1" />
-      <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="2.1.0" />
-      <dependency id="Microsoft.AspNetCore.WebSockets" version="2.0.1" />
-      <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.1" />
+      <dependency id="MQTTnet" version="2.8.5-rc2" />
+      <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="2.1.3" />
+      <dependency id="Microsoft.AspNetCore.WebSockets" version="2.1.1" />
+      <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -10,13 +10,11 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is a support library to integrate MQTTnet into AspNetCore.</description>
-    <releaseNotes> * For more release notes please check the MQTTnet release notes.
- * [Server] fixed cpu spike in case a client disconnectes (issue 421)
-    </releaseNotes>
+    <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.4" />
+      <dependency id="MQTTnet" version="2.8.5-rc1" />
       <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="2.1.0" />
       <dependency id="Microsoft.AspNetCore.WebSockets" version="2.0.1" />
       <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.1" />

--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.2" />
+      <dependency id="MQTTnet" version="2.8.3" />
       <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="2.1.0" />
       <dependency id="Microsoft.AspNetCore.WebSockets" version="2.0.1" />
       <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.1" />

--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -10,7 +10,8 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is a support library to integrate MQTTnet into AspNetCore.</description>
-    <releaseNotes>* For more release notes please check the MQTTnet release notes.
+    <releaseNotes> * For more release notes please check the MQTTnet release notes.
+ * [Server] fixed cpu spike in case a client disconnectes (issue 421)
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>

--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.3" />
+      <dependency id="MQTTnet" version="2.8.4" />
       <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="2.1.0" />
       <dependency id="Microsoft.AspNetCore.WebSockets" version="2.0.1" />
       <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.1" />

--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -10,7 +10,9 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is a support library to integrate MQTTnet into AspNetCore.</description>
-    <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
+    <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).
+ * fixed concurrent sends with Aspnetcore.Connections.Abstractions based transport
+    </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>

--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -16,7 +16,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.5-rc2" />
+      <dependency id="MQTTnet" version="2.8.5-rc3" />
       <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="2.1.3" />
       <dependency id="Microsoft.AspNetCore.WebSockets" version="2.1.1" />
       <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" />

--- a/Build/MQTTnet.Extensions.ManagedClient.nuspec
+++ b/Build/MQTTnet.Extensions.ManagedClient.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.3" />
+      <dependency id="MQTTnet" version="2.8.4" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.ManagedClient.nuspec
+++ b/Build/MQTTnet.Extensions.ManagedClient.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.2" />
+      <dependency id="MQTTnet" version="2.8.3" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.ManagedClient.nuspec
+++ b/Build/MQTTnet.Extensions.ManagedClient.nuspec
@@ -10,12 +10,11 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is an extension library which provides a managed MQTT client with additional features using MQTTnet.</description>
-    <releaseNotes>* For more release notes please check the MQTTnet release notes.
-    </releaseNotes>
+    <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.4" />
+      <dependency id="MQTTnet" version="2.8.5-rc1" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.ManagedClient.nuspec
+++ b/Build/MQTTnet.Extensions.ManagedClient.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.5-rc1" />
+      <dependency id="MQTTnet" version="2.8.5-rc3" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.Rpc.nuspec
+++ b/Build/MQTTnet.Extensions.Rpc.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.3" />
+      <dependency id="MQTTnet" version="2.8.4" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.Rpc.nuspec
+++ b/Build/MQTTnet.Extensions.Rpc.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.2" />
+      <dependency id="MQTTnet" version="2.8.3" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.Rpc.nuspec
+++ b/Build/MQTTnet.Extensions.Rpc.nuspec
@@ -10,12 +10,11 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is an extension library which allows executing synchronous device calls including a response using MQTTnet.</description>
-    <releaseNotes>* For more release notes please check the MQTTnet release notes.
-    </releaseNotes>
+    <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.4" />
+      <dependency id="MQTTnet" version="2.8.5-rc1" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.Extensions.Rpc.nuspec
+++ b/Build/MQTTnet.Extensions.Rpc.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
-      <dependency id="MQTTnet" version="2.8.5-rc1" />
+      <dependency id="MQTTnet" version="2.8.5-rc3" />
     </dependencies>
   </metadata>
 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -24,7 +24,7 @@
         <dependency id="NETStandard.Library" version="1.3.0" />
         <dependency id="System.Net.Security" version="4.3.2" />
         <dependency id="System.Net.WebSockets" version="4.3.0" />
-        <dependency id="System.Net.WebSockets.Client" version="4.3.1" />      
+        <dependency id="System.Net.WebSockets.Client" version="4.3.2" />      
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.0" />
@@ -33,7 +33,7 @@
         <dependency id="System.Net.WebSockets.Client" version="4.3.2" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.4" />
+        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.9" />
       </group>
       <group targetFramework="net452">
       </group>

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -10,10 +10,7 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
-    <releaseNotes>* [Core] Added all factory methods to the factory interface.
-* [Core] Fixed an issue with cancellation token handling (thanks to @acrabb).
-* [Server] Added a new overload for configuring the ASP.net integration (thanks to @JanEggers).
-* [Server] Added a method for clearing all retained messages.
+    <releaseNotes>* [Client] Fixed a deadlock when an exception is fired while connecting (thanks to @malibVB).
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -12,6 +12,8 @@
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
     <releaseNotes>* [Server] Added new method which exposes all retained messages.
 * [Server] Removed (wrong) setter from the server options interface.
+* [ManagedClient] Added max pending messages count option.
+* [ManagedClient] Add pending messages overflow strategy option.
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -10,10 +10,11 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
-    <releaseNotes>* [Server] Added new method which exposes all retained messages.
-* [Server] Removed (wrong) setter from the server options interface.
-* [ManagedClient] Added max pending messages count option.
+    <releaseNotes>* [ManagedClient] Added max pending messages count option.
 * [ManagedClient] Add pending messages overflow strategy option.
+* [Server] Added new method which exposes all retained messages.
+* [Server] Removed (wrong) setter from the server options interface.
+* [Server] fixed cpu spike in case a client disconnectes (issue 421)
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -11,6 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
     <releaseNotes>* [Server] Added new method which exposes all retained messages.
+* [Server] Removed (wrong) setter from the server options interface.
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -10,7 +10,7 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
-    <releaseNotes>* [Client] Fixed a deadlock when an exception is fired while connecting (thanks to @malibVB).
+    <releaseNotes>* [Server] Added new method which exposes all retained messages.
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -11,7 +11,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
     <releaseNotes>* [Core] Added all factory methods to the factory interface.
+* [Core] Fixed an issue with cancellation token handling (thanks to @acrabb).
 * [Server] Added a new overload for configuring the ASP.net integration (thanks to @JanEggers).
+* [Server] Added a method for clearing all retained messages.
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2018</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -10,7 +10,8 @@
     <iconUrl>https://raw.githubusercontent.com/chkr1011/MQTTnet/master/Images/Logo_128x128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MQTTnet is a high performance .NET library for MQTT based communication. It provides a MQTT client and a MQTT server (broker).</description>
-    <releaseNotes>* [ManagedClient] Added max pending messages count option.
+    <releaseNotes> * [Core] Updated nuget packages due to security issues.
+* [ManagedClient] Added max pending messages count option.
 * [ManagedClient] Add pending messages overflow strategy option.
 * [Server] Added new method which exposes all retained messages.
 * [Server] Removed (wrong) setter from the server options interface.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MQTTnet is a high performance .NET library for MQTT based communication. It prov
 * Performance optimized (processing ~70.000 messages / second)*
 * Interfaces included for mocking and testing
 * Access to internal trace messages
-* Unit tested (~90 tests)
+* Unit tested (~100 tests)
 
 \* Tested on local machine (Intel i7 8700K) with MQTTnet client and server running in the same process using the TCP channel. The app for verification is part of this repository and stored in _/Tests/MQTTnet.TestApp.NetCore_.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <p align="center">
 <img src="https://github.com/chkr1011/MQTTnet/blob/master/Images/Logo_128x128.png?raw=true" width="128">
+<br/>
+<br/>
 </p>
 
 [![NuGet Badge](https://buildstats.info/nuget/MQTTnet)](https://www.nuget.org/packages/MQTTnet)
-[![Build status](https://ci.appveyor.com/api/projects/status/ycit86voxfevm2aa/branch/master?svg=true)](https://ci.appveyor.com/project/chkr1011/mqttnet/branch/develop)
+[![Build status](https://ci.appveyor.com/api/projects/status/ycit86voxfevm2aa/branch/master?svg=true)](https://ci.appveyor.com/project/chkr1011/mqttnet)
 [![BCH compliance](https://bettercodehub.com/edge/badge/chkr1011/MQTTnet?branch=master)](https://bettercodehub.com/)
 [![OpenCollective](https://opencollective.com/mqttnet/backers/badge.svg)](https://opencollective.com/mqttnet) 
 [![OpenCollective](https://opencollective.com/mqttnet/sponsors/badge.svg)](https://opencollective.com/mqttnet)

--- a/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
+++ b/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Connections;
 using MQTTnet.Adapter;
 using MQTTnet.AspNetCore.Client.Tcp;
+using MQTTnet.Exceptions;
 using MQTTnet.Packets;
 using MQTTnet.Serializer;
 using System;
@@ -83,7 +84,7 @@ namespace MQTTnet.AspNetCore
                         }
                         else if (readResult.IsCompleted)
                         {
-                            break;
+                            throw new MqttCommunicationException("Connection Aborted");
                         }
                     }
                     finally

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -62,7 +62,7 @@ namespace MQTTnet.AspNetCore
                     }
                     else
                     {
-                        readResult = await readTask;
+                        readResult = await readTask.ConfigureAwait(false);
                     }
 
                     var buffer = readResult.Buffer;
@@ -115,7 +115,7 @@ namespace MQTTnet.AspNetCore
             await _writerSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                await output.WriteAsync(buffer, cancellationToken);
+                await output.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/Source/MQTTnet.Extensions.ManagedClient/ApplicationMessageSkippedEventArgs.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ApplicationMessageSkippedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MQTTnet.Extensions.ManagedClient
+{
+    public class ApplicationMessageSkippedEventArgs : EventArgs
+    {
+        public ApplicationMessageSkippedEventArgs(ManagedMqttApplicationMessage applicationMessage)
+        {
+            ApplicationMessage = applicationMessage ?? throw new ArgumentNullException(nameof(applicationMessage));
+        }
+
+        public ManagedMqttApplicationMessage ApplicationMessage { get; }
+    }
+}

--- a/Source/MQTTnet.Extensions.ManagedClient/IManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/IManagedMqttClient.cs
@@ -15,6 +15,7 @@ namespace MQTTnet.Extensions.ManagedClient
         event EventHandler<MqttClientDisconnectedEventArgs> Disconnected;
 
         event EventHandler<ApplicationMessageProcessedEventArgs> ApplicationMessageProcessed;
+        event EventHandler<ApplicationMessageSkippedEventArgs> ApplicationMessageSkipped;
 
         event EventHandler<MqttManagedProcessFailedEventArgs> ConnectingFailed;
         event EventHandler<MqttManagedProcessFailedEventArgs> SynchronizingSubscriptionsFailed;

--- a/Source/MQTTnet.Extensions.ManagedClient/IManagedMqttClientOptions.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/IManagedMqttClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MQTTnet.Client;
+using MQTTnet.Server;
 
 namespace MQTTnet.Extensions.ManagedClient
 {
@@ -12,5 +13,9 @@ namespace MQTTnet.Extensions.ManagedClient
         TimeSpan ConnectionCheckInterval { get; }
 
         IManagedMqttClientStorage Storage { get; }
+
+        int MaxPendingMessages { get; }
+
+        MqttPendingMessagesOverflowStrategy PendingMessagesOverflowStrategy { get; }
     }
 }

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -116,7 +116,7 @@ namespace MQTTnet.Extensions.ManagedClient
             ManagedMqttApplicationMessage skippedMessage = null;
             lock (_messageQueue)
             {
-                if (_messageQueue.Count > _options.MaxPendingMessages)
+                if (_messageQueue.Count >= _options.MaxPendingMessages)
                 {
                     if (_options.PendingMessagesOverflowStrategy == MqttPendingMessagesOverflowStrategy.DropNewMessage)
                     {

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -226,7 +226,7 @@ namespace MQTTnet.Extensions.ManagedClient
         {
             try
             {
-                while (!cancellationToken.IsCancellationRequested)
+                while (!cancellationToken.IsCancellationRequested && _mqttClient.IsConnected)
                 {
                     var message = _messageQueue.Take(cancellationToken);
                     if (message == null)
@@ -367,7 +367,6 @@ namespace MQTTnet.Extensions.ManagedClient
             }
 
             var cts = new CancellationTokenSource();
-
             _publishingCancellationToken = cts;
 
             Task.Factory.StartNew(() => PublishQueuedMessages(cts.Token), cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -113,7 +113,7 @@ namespace MQTTnet.Extensions.ManagedClient
         {
             if (applicationMessage == null) throw new ArgumentNullException(nameof(applicationMessage));
 
-            ManagedMqttApplicationMessage skippedMessage = null;
+            ManagedMqttApplicationMessage removedMessage = null;
             lock (_messageQueue)
             {
                 if (_messageQueue.Count >= _options.MaxPendingMessages)
@@ -127,9 +127,9 @@ namespace MQTTnet.Extensions.ManagedClient
 
                     if (_options.PendingMessagesOverflowStrategy == MqttPendingMessagesOverflowStrategy.DropOldestQueuedMessage)
                     {
-                        skippedMessage = _messageQueue.RemoveFirst();
+                        removedMessage = _messageQueue.RemoveFirst();
                         _logger.Verbose("Removed oldest application message from internal queue because it is full.");
-                        ApplicationMessageSkipped?.Invoke(this, new ApplicationMessageSkippedEventArgs(skippedMessage));
+                        ApplicationMessageSkipped?.Invoke(this, new ApplicationMessageSkippedEventArgs(removedMessage));
                     }
                 }
 
@@ -138,9 +138,9 @@ namespace MQTTnet.Extensions.ManagedClient
 
             if (_storageManager != null)
             {
-                if (skippedMessage != null)
+                if (removedMessage != null)
                 {
-                    await _storageManager.RemoveAsync(skippedMessage).ConfigureAwait(false);
+                    await _storageManager.RemoveAsync(removedMessage).ConfigureAwait(false);
                 }
 
                 await _storageManager.AddAsync(applicationMessage).ConfigureAwait(false);

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientOptions.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MQTTnet.Client;
+using MQTTnet.Server;
 
 namespace MQTTnet.Extensions.ManagedClient
 {
@@ -12,5 +13,9 @@ namespace MQTTnet.Extensions.ManagedClient
         public TimeSpan ConnectionCheckInterval { get; set; } = TimeSpan.FromSeconds(1);
 
         public IManagedMqttClientStorage Storage { get; set; }
+
+        public int MaxPendingMessages { get; set; } = int.MaxValue;
+
+        public MqttPendingMessagesOverflowStrategy PendingMessagesOverflowStrategy { get; set; } = MqttPendingMessagesOverflowStrategy.DropNewMessage;
     }
 }

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientOptionsBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MQTTnet.Client;
+using MQTTnet.Server;
 
 namespace MQTTnet.Extensions.ManagedClient
 {
@@ -7,6 +8,18 @@ namespace MQTTnet.Extensions.ManagedClient
     {
         private readonly ManagedMqttClientOptions _options = new ManagedMqttClientOptions();
         private MqttClientOptionsBuilder _clientOptionsBuilder;
+
+        public ManagedMqttClientOptionsBuilder WithMaxPendingMessages(int value)
+        {
+            _options.MaxPendingMessages = value;
+            return this;
+        }
+
+        public ManagedMqttClientOptionsBuilder WithPendingMessagesOverflowStrategy(MqttPendingMessagesOverflowStrategy value)
+        {
+            _options.PendingMessagesOverflowStrategy = value;
+            return this;
+        }
 
         public ManagedMqttClientOptionsBuilder WithAutoReconnectDelay(TimeSpan value)
         {

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientStorageManager.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientStorageManager.cs
@@ -28,6 +28,8 @@ namespace MQTTnet.Extensions.ManagedClient
 
         public async Task AddAsync(ManagedMqttApplicationMessage applicationMessage)
         {
+            if (applicationMessage == null) throw new ArgumentNullException(nameof(applicationMessage));
+
             using (await _messagesLock.LockAsync(CancellationToken.None).ConfigureAwait(false))
             {
                 _messages.Add(applicationMessage);
@@ -37,6 +39,8 @@ namespace MQTTnet.Extensions.ManagedClient
 
         public async Task RemoveAsync(ManagedMqttApplicationMessage applicationMessage)
         {
+            if (applicationMessage == null) throw new ArgumentNullException(nameof(applicationMessage));
+
             using (await _messagesLock.LockAsync(CancellationToken.None).ConfigureAwait(false))
             {
                 var index = _messages.IndexOf(applicationMessage);

--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -150,6 +150,9 @@ namespace MQTTnet.Adapter
 
                 return packet;
             }
+            catch (OperationCanceledException)
+            {
+            }
             catch (Exception exception)
             {
                 if (IsWrappedException(exception))
@@ -237,7 +240,8 @@ namespace MQTTnet.Adapter
         {
             if (exception is IOException && exception.InnerException is SocketException socketException)
             {
-                if (socketException.SocketErrorCode == SocketError.ConnectionAborted)
+                if (socketException.SocketErrorCode == SocketError.ConnectionAborted ||
+                    socketException.SocketErrorCode == SocketError.OperationAborted)
                 {
                     throw new OperationCanceledException();
                 }

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -29,7 +29,7 @@ namespace MQTTnet.Client
         internal Task _keepAliveMessageSenderTask;
         private IMqttChannelAdapter _adapter;
         private bool _cleanDisconnectInitiated;
-        private int _disconnectGate;
+        private long _disconnectGate;
 
         public MqttClient(IMqttClientAdapterFactory channelFactory, IMqttNetLogger logger)
         {
@@ -216,7 +216,7 @@ namespace MQTTnet.Client
 
         private void ThrowIfNotConnected()
         {
-            if (!IsConnected) throw new MqttCommunicationException("The client is not connected.");
+            if (!IsConnected || Interlocked.Read(ref _disconnectGate) == 1) throw new MqttCommunicationException("The client is not connected.");
         }
 
         private void ThrowIfConnected(string message)

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -183,10 +183,12 @@ namespace MQTTnet.Client
 
         public void Dispose()
         {
+            _cancellationTokenSource?.Cancel (false);
             _cancellationTokenSource?.Dispose();
             _cancellationTokenSource = null;
 
             _adapter?.Dispose();
+            _adapter = null;
         }
 
         private async Task<MqttConnAckPacket> AuthenticateAsync(MqttApplicationMessage willApplicationMessage, CancellationToken cancellationToken)
@@ -245,10 +247,7 @@ namespace MQTTnet.Client
             }
             finally
             {
-                _adapter?.Dispose();
-                _adapter = null;
-                _cancellationTokenSource?.Dispose();
-                _cancellationTokenSource = null;
+                Dispose ();
                 _cleanDisconnectInitiated = false;
 
                 _logger.Info("Disconnected.");
@@ -394,6 +393,7 @@ namespace MQTTnet.Client
 
                 if (exception is OperationCanceledException)
                 {
+                    _logger.Verbose ("MQTT OperationCanceled exception while receiving packets.");
                 }
                 else if (exception is MqttCommunicationException)
                 {

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -116,7 +116,7 @@ namespace MQTTnet.Implementations
                 return true;
             }
 
-            if (chain.ChainStatus.Any(c => c.Status == X509ChainStatusFlags.RevocationStatusUnknown || c.Status == X509ChainStatusFlags.Revoked || c.Status == X509ChainStatusFlags.RevocationStatusUnknown))
+            if (chain.ChainStatus.Any(c => c.Status == X509ChainStatusFlags.RevocationStatusUnknown || c.Status == X509ChainStatusFlags.Revoked || c.Status == X509ChainStatusFlags.OfflineRevocation))
             {
                 if (!_options.TlsOptions.IgnoreCertificateRevocationErrors)
                 {

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -20,8 +20,8 @@ namespace MQTTnet.Implementations
         private readonly CancellationToken _cancellationToken;
         private readonly AddressFamily _addressFamily;
         private readonly MqttServerTcpEndpointBaseOptions _options;
+        private readonly MqttServerTlsTcpEndpointOptions _tlsOptions;
         private readonly X509Certificate2 _tlsCertificate;
-
         private Socket _socket;
 
         public MqttTcpServerListener(
@@ -36,6 +36,11 @@ namespace MQTTnet.Implementations
             _tlsCertificate = tlsCertificate;
             _cancellationToken = cancellationToken;
             _logger = logger.CreateChildLogger(nameof(MqttTcpServerListener));
+            
+            if (_options is MqttServerTlsTcpEndpointOptions tlsOptions)
+            {
+                _tlsOptions = tlsOptions;
+            }
         }
 
         public event EventHandler<MqttServerAdapterClientAcceptedEventArgs> ClientAccepted;
@@ -75,7 +80,7 @@ namespace MQTTnet.Implementations
                     if (_tlsCertificate != null)
                     {
                         sslStream = new SslStream(new NetworkStream(clientSocket), false);
-                        await sslStream.AuthenticateAsServerAsync(_tlsCertificate, false, SslProtocols.Tls12, false).ConfigureAwait(false);
+                        await sslStream.AuthenticateAsServerAsync(_tlsCertificate, false, _tlsOptions.SslProtocol, false).ConfigureAwait(false);
                     }
 
                     _logger.Verbose("Client '{0}' accepted by TCP listener '{1}, {2}'.",

--- a/Source/MQTTnet/Internal/BlockingQueue.cs
+++ b/Source/MQTTnet/Internal/BlockingQueue.cs
@@ -62,6 +62,7 @@ namespace MQTTnet.Internal
             {
                 var item = _items.First;
                 _items.RemoveFirst();
+
                 return item.Value;
             }
         }

--- a/Source/MQTTnet/Internal/BlockingQueue.cs
+++ b/Source/MQTTnet/Internal/BlockingQueue.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MQTTnet.Internal
+{
+    public class BlockingQueue<TItem>
+    {
+        private readonly object _syncRoot = new object();
+        private readonly LinkedList<TItem> _items = new LinkedList<TItem>();
+        private readonly ManualResetEvent _gate = new ManualResetEvent(false);
+
+        public int Count
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _items.Count;
+                }
+            }
+        }
+
+        public void Enqueue(TItem item)
+        {
+            if (item == null) throw new ArgumentNullException(nameof(item));
+
+            lock (_syncRoot)
+            {
+                _items.AddLast(item);
+                _gate.Set();
+            }
+        }
+
+        public TItem Dequeue()
+        {
+            while (true)
+            {
+                lock (_syncRoot)
+                {
+                    if (_items.Count > 0)
+                    {
+                        var item = _items.First.Value;
+                        _items.RemoveFirst();
+
+                        return item;
+                    }
+
+                    if (_items.Count == 0)
+                    {
+                        _gate.Reset();
+                    }
+                }
+
+                _gate.WaitOne();
+            }
+        }
+
+        public TItem RemoveFirst()
+        {
+            lock (_syncRoot)
+            {
+                var item = _items.First;
+                _items.RemoveFirst();
+                return item.Value;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_syncRoot)
+            {
+                _items.Clear();
+            }
+        }
+    }
+}

--- a/Source/MQTTnet/MQTTnet.csproj
+++ b/Source/MQTTnet/MQTTnet.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='uap10.0'">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">

--- a/Source/MQTTnet/Server/IMqttServer.cs
+++ b/Source/MQTTnet/Server/IMqttServer.cs
@@ -16,14 +16,18 @@ namespace MQTTnet.Server
         
         IMqttServerOptions Options { get; }
 
+        [Obsolete("This method is no longer async. Use the not async method.")]
         Task<IList<IMqttClientSessionStatus>> GetClientSessionsStatusAsync();
+
+        IList<IMqttClientSessionStatus> GetClientSessionsStatus();
+
+        IList<MqttApplicationMessage> GetRetainedMessages();
+        Task ClearRetainedMessagesAsync();
 
         Task SubscribeAsync(string clientId, IList<TopicFilter> topicFilters);
         Task UnsubscribeAsync(string clientId, IList<string> topicFilters);
 
         Task StartAsync(IMqttServerOptions options);
         Task StopAsync();
-
-        Task ClearRetainedMessagesAsync();
     }
 }

--- a/Source/MQTTnet/Server/IMqttServer.cs
+++ b/Source/MQTTnet/Server/IMqttServer.cs
@@ -23,5 +23,7 @@ namespace MQTTnet.Server
 
         Task StartAsync(IMqttServerOptions options);
         Task StopAsync();
+
+        Task ClearRetainedMessagesAsync();
     }
 }

--- a/Source/MQTTnet/Server/IMqttServerOptions.cs
+++ b/Source/MQTTnet/Server/IMqttServerOptions.cs
@@ -14,7 +14,7 @@ namespace MQTTnet.Server
         Action<MqttConnectionValidatorContext> ConnectionValidator { get; }
         Action<MqttSubscriptionInterceptorContext> SubscriptionInterceptor { get; }
         Action<MqttApplicationMessageInterceptorContext> ApplicationMessageInterceptor { get; }
-        Action<MqttClientMessageQueueInterceptorContext> ClientMessageQueueInterceptor { get; set; }
+        Action<MqttClientMessageQueueInterceptorContext> ClientMessageQueueInterceptor { get; }
 
         MqttServerTcpEndpointOptions DefaultEndpointOptions { get; }
         MqttServerTlsTcpEndpointOptions TlsEndpointOptions { get; }

--- a/Source/MQTTnet/Server/MqttClientSession.cs
+++ b/Source/MQTTnet/Server/MqttClientSession.cs
@@ -138,7 +138,9 @@ namespace MQTTnet.Server
 
                 _cleanupHandle?.Dispose();
                 _cleanupHandle = null;
-
+                
+                _adapter = null;
+                _cancellationTokenSource?.Cancel(false);
                 _cancellationTokenSource?.Dispose();
                 _cancellationTokenSource = null;
             }
@@ -290,7 +292,9 @@ namespace MQTTnet.Server
         {
             _pendingPacketsQueue?.Dispose();
 
+            _cancellationTokenSource?.Cancel ();
             _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = null;
         }
 
         private void ProcessReceivedPacket(IMqttChannelAdapter adapter, MqttBasePacket packet, CancellationToken cancellationToken)

--- a/Source/MQTTnet/Server/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/MqttClientSessionsManager.cs
@@ -65,7 +65,7 @@ namespace MQTTnet.Server
             return Task.Run(() => RunSession(clientAdapter, _cancellationToken), _cancellationToken);
         }
 
-        public Task<IList<IMqttClientSessionStatus>> GetClientStatusAsync()
+        public IList<IMqttClientSessionStatus> GetClientStatus()
         {
             var result = new List<IMqttClientSessionStatus>();
 
@@ -77,7 +77,7 @@ namespace MQTTnet.Server
                 result.Add(status);
             }
 
-            return Task.FromResult((IList<IMqttClientSessionStatus>)result);
+            return result;
         }
 
         public void EnqueueApplicationMessage(MqttClientSession senderClientSession, MqttPublishPacket publishPacket)

--- a/Source/MQTTnet/Server/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/MqttRetainedMessagesManager.cs
@@ -93,7 +93,7 @@ namespace MQTTnet.Server
                 if (applicationMessage.Payload?.Length == 0)
                 {
                     saveIsRequired = _messages.Remove(applicationMessage.Topic);
-                    _logger.Info("Client '{0}' cleared retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                    _logger.Verbose("Client '{0}' cleared retained message for topic '{1}'.", clientId, applicationMessage.Topic);
                 }
                 else
                 {
@@ -111,7 +111,7 @@ namespace MQTTnet.Server
                         }
                     }
 
-                    _logger.Info("Client '{0}' set retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                    _logger.Verbose("Client '{0}' set retained message for topic '{1}'.", clientId, applicationMessage.Topic);
                 }
             }
 

--- a/Source/MQTTnet/Server/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/MqttRetainedMessagesManager.cs
@@ -84,6 +84,16 @@ namespace MQTTnet.Server
             return retainedMessages;
         }
 
+        public Task ClearMessagesAsync()
+        {
+            lock (_messages)
+            {
+                _messages.Clear();
+            }
+
+            return _options.Storage.SaveRetainedMessagesAsync(new List<MqttApplicationMessage>());
+        }
+
         private async Task HandleMessageInternalAsync(string clientId, MqttApplicationMessage applicationMessage)
         {
             var saveIsRequired = false;

--- a/Source/MQTTnet/Server/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/MqttRetainedMessagesManager.cs
@@ -52,7 +52,51 @@ namespace MQTTnet.Server
 
             try
             {
-                await HandleMessageInternalAsync(clientId, applicationMessage).ConfigureAwait(false);
+                List<MqttApplicationMessage> messagesForSave = null;
+                lock (_messages)
+                {
+                    var saveIsRequired = false;
+
+                    if (applicationMessage.Payload?.Length == 0)
+                    {
+                        saveIsRequired = _messages.Remove(applicationMessage.Topic);
+                        _logger.Verbose("Client '{0}' cleared retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                    }
+                    else
+                    {
+                        if (!_messages.TryGetValue(applicationMessage.Topic, out var existingMessage))
+                        {
+                            _messages[applicationMessage.Topic] = applicationMessage;
+                            saveIsRequired = true;
+                        }
+                        else
+                        {
+                            if (existingMessage.QualityOfServiceLevel != applicationMessage.QualityOfServiceLevel || !existingMessage.Payload.SequenceEqual(applicationMessage.Payload ?? new byte[0]))
+                            {
+                                _messages[applicationMessage.Topic] = applicationMessage;
+                                saveIsRequired = true;
+                            }
+                        }
+
+                        _logger.Verbose("Client '{0}' set retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                    }
+
+                    if (saveIsRequired)
+                    {
+                        messagesForSave = new List<MqttApplicationMessage>(_messages.Values);
+                    }
+                }
+
+                if (messagesForSave == null)
+                {
+                    _logger.Verbose("Skipped saving retained messages because no changes were detected.");
+                    return;
+                }
+
+                if (_options.Storage != null)
+                {
+                    await _options.Storage.SaveRetainedMessagesAsync(messagesForSave).ConfigureAwait(false);
+                }
             }
             catch (Exception exception)
             {
@@ -84,6 +128,14 @@ namespace MQTTnet.Server
             return retainedMessages;
         }
 
+        public IList<MqttApplicationMessage> GetMessages()
+        {
+            lock (_messages)
+            {
+                return _messages.Values.ToList();
+            }
+        }
+
         public Task ClearMessagesAsync()
         {
             lock (_messages)
@@ -91,55 +143,12 @@ namespace MQTTnet.Server
                 _messages.Clear();
             }
 
-            return _options.Storage.SaveRetainedMessagesAsync(new List<MqttApplicationMessage>());
-        }
-
-        private async Task HandleMessageInternalAsync(string clientId, MqttApplicationMessage applicationMessage)
-        {
-            var saveIsRequired = false;
-
-            lock (_messages)
+            if (_options.Storage != null)
             {
-                if (applicationMessage.Payload?.Length == 0)
-                {
-                    saveIsRequired = _messages.Remove(applicationMessage.Topic);
-                    _logger.Verbose("Client '{0}' cleared retained message for topic '{1}'.", clientId, applicationMessage.Topic);
-                }
-                else
-                {
-                    if (!_messages.TryGetValue(applicationMessage.Topic, out var existingMessage))
-                    {
-                        _messages[applicationMessage.Topic] = applicationMessage;
-                        saveIsRequired = true;
-                    }
-                    else
-                    {
-                        if (existingMessage.QualityOfServiceLevel != applicationMessage.QualityOfServiceLevel || !existingMessage.Payload.SequenceEqual(applicationMessage.Payload ?? new byte[0]))
-                        {
-                            _messages[applicationMessage.Topic] = applicationMessage;
-                            saveIsRequired = true;
-                        }
-                    }
-
-                    _logger.Verbose("Client '{0}' set retained message for topic '{1}'.", clientId, applicationMessage.Topic);
-                }
+                return _options.Storage.SaveRetainedMessagesAsync(new List<MqttApplicationMessage>());
             }
 
-            if (!saveIsRequired)
-            {
-                _logger.Verbose("Skipped saving retained messages because no changes were detected.");
-            }
-
-            if (saveIsRequired && _options.Storage != null)
-            {
-                List<MqttApplicationMessage> messages;
-                lock (_messages)
-                {
-                    messages = _messages.Values.ToList();
-                }
-
-                await _options.Storage.SaveRetainedMessagesAsync(messages).ConfigureAwait(false);
-            }
+            return Task.FromResult((object)null);
         }
     }
 }

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -129,6 +129,11 @@ namespace MQTTnet.Server
             }
         }
 
+        public Task ClearRetainedMessagesAsync()
+        {
+            return _retainedMessagesManager?.ClearMessagesAsync();
+        }
+
         internal void OnClientConnected(string clientId)
         {
             _logger.Info("Client '{0}': Connected.", clientId);

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -41,7 +41,17 @@ namespace MQTTnet.Server
 
         public Task<IList<IMqttClientSessionStatus>> GetClientSessionsStatusAsync()
         {
-            return _clientSessionsManager.GetClientStatusAsync();
+            return Task.FromResult(_clientSessionsManager.GetClientStatus());
+        }
+
+        public IList<IMqttClientSessionStatus> GetClientSessionsStatus()
+        {
+            return _clientSessionsManager.GetClientStatus();
+        }
+
+        public IList<MqttApplicationMessage> GetRetainedMessages()
+        {
+            return _retainedMessagesManager.GetMessages();
         }
 
         public Task SubscribeAsync(string clientId, IList<TopicFilter> topicFilters)

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Security.Authentication;
 
 namespace MQTTnet.Server
 {
@@ -77,6 +78,12 @@ namespace MQTTnet.Server
         public MqttServerOptionsBuilder WithEncryptionCertificate(byte[] value)
         {
             _options.TlsEndpointOptions.Certificate = value;
+            return this;
+        }
+
+        public MqttServerOptionsBuilder WithEncryptionSslProtocol(SslProtocols value)
+        {
+            _options.TlsEndpointOptions.SslProtocol = value;
             return this;
         }
 

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace MQTTnet.Server
+﻿using System.Security.Authentication;
+
+namespace MQTTnet.Server
 {
     public class MqttServerTlsTcpEndpointOptions : MqttServerTcpEndpointBaseOptions
     {
@@ -8,5 +10,8 @@
         }
 
         public byte[] Certificate { get; set; }
+
+
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
     }
 }

--- a/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
+++ b/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
+++ b/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MQTTnet.AspNetCore.Tests/Mockups/ConnectionContextMockup.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/Mockups/ConnectionContextMockup.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace MQTTnet.AspNetCore.Tests.Mockups
+{
+    public class ConnectionContextMockup : ConnectionContext
+    {
+        public override string ConnectionId { get; set; }
+
+        public override IFeatureCollection Features { get; }
+
+        public override IDictionary<object, object> Items { get; set; }
+        public override IDuplexPipe Transport { get; set; }
+
+        public ConnectionContextMockup()
+        {
+            //Transport = new DefaultConnectionContext
+        }
+    }
+}

--- a/Tests/MQTTnet.AspNetCore.Tests/Mockups/DuplexPipeMockup.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/Mockups/DuplexPipeMockup.cs
@@ -1,0 +1,16 @@
+﻿using System.IO.Pipelines;
+
+namespace MQTTnet.AspNetCore.Tests.Mockups
+{
+    public class DuplexPipeMockup : IDuplexPipe
+    {
+        PipeReader IDuplexPipe.Input => Receive.Reader;
+
+        PipeWriter IDuplexPipe.Output => Send.Writer;
+
+
+        public Pipe Receive { get; set; } = new Pipe();
+
+        public Pipe Send { get; set; } = new Pipe();
+    }
+}

--- a/Tests/MQTTnet.AspNetCore.Tests/MqttConnectionContextTest.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/MqttConnectionContextTest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Connections;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.AspNetCore.Tests.Mockups;
+using MQTTnet.Exceptions;
+using MQTTnet.Serializer;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MQTTnet.AspNetCore.Tests
+{
+    [TestClass]
+    public class MqttConnectionContextTest
+    {
+        [TestMethod]
+        public async Task TestReceivePacketAsyncThrowsWhenReaderCompleted()
+        {
+            var serializer = new MqttPacketSerializer {};
+            var pipe = new DuplexPipeMockup();
+            var connection = new DefaultConnectionContext();
+            connection.Transport = pipe;
+            var ctx = new MqttConnectionContext(serializer, connection);
+
+            pipe.Receive.Writer.Complete();
+
+            await Assert.ThrowsExceptionAsync<MqttCommunicationException>(() => ctx.ReceivePacketAsync(TimeSpan.FromSeconds(1), CancellationToken.None));
+        }
+    }
+}

--- a/Tests/MQTTnet.AspNetCore.Tests/MqttConnectionContextTest.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/MqttConnectionContextTest.cs
@@ -2,8 +2,10 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MQTTnet.AspNetCore.Tests.Mockups;
 using MQTTnet.Exceptions;
+using MQTTnet.Packets;
 using MQTTnet.Serializer;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,6 +26,26 @@ namespace MQTTnet.AspNetCore.Tests
             pipe.Receive.Writer.Complete();
 
             await Assert.ThrowsExceptionAsync<MqttCommunicationException>(() => ctx.ReceivePacketAsync(TimeSpan.FromSeconds(1), CancellationToken.None));
+        }
+        
+        [TestMethod]
+        public async Task TestParallelWrites()
+        {
+            var serializer = new MqttPacketSerializer { };
+            var pipe = new DuplexPipeMockup();
+            var connection = new DefaultConnectionContext();
+            connection.Transport = pipe;
+            var ctx = new MqttConnectionContext(serializer, connection);
+
+            var tasks = Enumerable.Range(1, 10).Select(_ => Task.Run(async () => 
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    await ctx.SendPacketAsync(new MqttPublishPacket(), CancellationToken.None).ConfigureAwait(false);
+                }
+            }));
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }
 }

--- a/Tests/MQTTnet.Benchmarks/LoggerBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/LoggerBenchmark.cs
@@ -1,6 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Exporters;
-using BenchmarkDotNet.Attributes.Jobs;
 using MQTTnet.Diagnostics;
 
 namespace MQTTnet.Benchmarks

--- a/Tests/MQTTnet.Benchmarks/MQTTnet.Benchmarks.csproj
+++ b/Tests/MQTTnet.Benchmarks/MQTTnet.Benchmarks.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MQTTnet.Benchmarks/MessageProcessingBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/MessageProcessingBenchmark.cs
@@ -1,7 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Columns;
-using BenchmarkDotNet.Attributes.Exporters;
-using BenchmarkDotNet.Attributes.Jobs;
 using MQTTnet.Client;
 using MQTTnet.Server;
 

--- a/Tests/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -2,8 +2,6 @@
 using MQTTnet.Packets;
 using MQTTnet.Serializer;
 using MQTTnet.Internal;
-using BenchmarkDotNet.Attributes.Jobs;
-using BenchmarkDotNet.Attributes.Exporters;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tests/MQTTnet.Benchmarks/TopicFilterComparerBenchmark.cs
+++ b/Tests/MQTTnet.Benchmarks/TopicFilterComparerBenchmark.cs
@@ -1,6 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Exporters;
-using BenchmarkDotNet.Attributes.Jobs;
 using MQTTnet.Server;
 using System;
 

--- a/Tests/MQTTnet.Core.Tests/BlockingQueueTests.cs
+++ b/Tests/MQTTnet.Core.Tests/BlockingQueueTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Internal;
+
+namespace MQTTnet.Core.Tests
+{
+    [TestClass]
+    public class BlockingQueueTests
+    {
+        [TestMethod]
+        public void Preserve_Order()
+        {
+            var queue = new BlockingQueue<string>();
+            queue.Enqueue("a");
+            queue.Enqueue("b");
+            queue.Enqueue("c");
+
+            Assert.AreEqual(3, queue.Count);
+
+            Assert.AreEqual("a", queue.Dequeue());
+            Assert.AreEqual("b", queue.Dequeue());
+            Assert.AreEqual("c", queue.Dequeue());
+        }
+
+        [TestMethod]
+        public void Remove_First_Items()
+        {
+            var queue = new BlockingQueue<string>();
+            queue.Enqueue("a");
+            queue.Enqueue("b");
+            queue.Enqueue("c");
+
+            Assert.AreEqual("a", queue.RemoveFirst());
+            Assert.AreEqual("b", queue.RemoveFirst());
+            
+            Assert.AreEqual(1, queue.Count);
+
+            Assert.AreEqual("c", queue.Dequeue());
+        }
+
+        [TestMethod]
+        public void Clear_Items()
+        {
+            var queue = new BlockingQueue<string>();
+            queue.Enqueue("a");
+            queue.Enqueue("b");
+            queue.Enqueue("c");
+
+            Assert.AreEqual(3, queue.Count);
+
+            queue.Clear();
+
+            Assert.AreEqual(0, queue.Count);
+        }
+
+        [TestMethod]
+        public async Task Wait_For_Item()
+        {
+            var queue = new BlockingQueue<string>();
+
+            string item = null;
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            Task.Run(() =>
+            {
+                item = queue.Dequeue();
+            });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+            await Task.Delay(100);
+
+            Assert.AreEqual(0, queue.Count);
+            Assert.AreEqual(null, item);
+
+            queue.Enqueue("x");
+
+            await Task.Delay(100);
+
+            Assert.AreEqual("x", item);
+            Assert.AreEqual(0, queue.Count);
+        }
+
+        [TestMethod]
+        public void Wait_For_Times()
+        {
+            var number = 0;
+
+            var queue = new BlockingQueue<int>();
+
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            Task.Run(async () =>
+            {
+                while (true)
+                {
+                    queue.Enqueue(1);
+                    await Task.Delay(100);
+                }
+            });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+            while (number < 50)
+            {
+                queue.Dequeue();
+                Interlocked.Increment(ref number);
+            }
+        }
+    }
+}

--- a/Tests/MQTTnet.Core.Tests/MQTTnet.Core.Tests.csproj
+++ b/Tests/MQTTnet.Core.Tests/MQTTnet.Core.Tests.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <DebugType>Full</DebugType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MQTTnet.Core.Tests/MQTTnet.Core.Tests.csproj
+++ b/Tests/MQTTnet.Core.Tests/MQTTnet.Core.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Source\MQTTnet.Extensions.ManagedClient\MQTTnet.Extensions.ManagedClient.csproj" />
     <ProjectReference Include="..\..\Source\MQTTnet\MQTTnet.csproj" />
   </ItemGroup>
 

--- a/Tests/MQTTnet.Core.Tests/ManagedMqttClientTests.cs
+++ b/Tests/MQTTnet.Core.Tests/ManagedMqttClientTests.cs
@@ -1,0 +1,38 @@
+﻿using MQTTnet.Extensions.ManagedClient;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Server;
+
+namespace MQTTnet.Core.Tests
+{
+    [TestClass]
+    public class ManagedMqttClientTests
+    {
+        [TestMethod]
+        public async Task Drop_New_Messages_On_Full_Queue()
+        {
+            var factory = new MqttFactory();
+            var managedClient = factory.CreateManagedMqttClient();
+
+            var clientOptions = new ManagedMqttClientOptionsBuilder()
+                .WithMaxPendingMessages(5)
+                .WithPendingMessagesOverflowStrategy(MqttPendingMessagesOverflowStrategy.DropNewMessage);
+
+            clientOptions.WithClientOptions(o => o.WithTcpServer("localhost"));
+
+            await managedClient.StartAsync(clientOptions.Build());
+
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "1" });
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "2" });
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "3" });
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "4" });
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "5" });
+
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "6" });
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "7" });
+            await managedClient.PublishAsync(new MqttApplicationMessage { Topic = "8" });
+
+            Assert.AreEqual(5, managedClient.PendingApplicationMessagesCount);
+        }
+    }
+}

--- a/Tests/MQTTnet.Core.Tests/MqttServerTests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttServerTests.cs
@@ -340,6 +340,8 @@ namespace MQTTnet.Core.Tests
                     }
                 });
 
+                await Task.Delay(100);
+
                 var retainedMessages = server.GetRetainedMessages();
 
                 Assert.AreEqual(ClientCount, retainedMessages.Count);

--- a/Tests/MQTTnet.Core.Tests/RoundtripTimeTests.cs
+++ b/Tests/MQTTnet.Core.Tests/RoundtripTimeTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Client;
+using MQTTnet.Server;
+
+namespace MQTTnet.Core.Tests
+{
+    [TestClass]
+    public class RoundtripTimeTests
+    {
+        [TestMethod]
+        public async Task Round_Trip_Time()
+        {
+            var factory = new MqttFactory();
+            var server = factory.CreateMqttServer();
+            var receiverClient = factory.CreateMqttClient();
+            var senderClient = factory.CreateMqttClient();
+
+            await server.StartAsync(new MqttServerOptionsBuilder().Build());
+
+            await receiverClient.ConnectAsync(new MqttClientOptionsBuilder().WithTcpServer("localhost").Build());
+            await receiverClient.SubscribeAsync("#");
+
+            await senderClient.ConnectAsync(new MqttClientOptionsBuilder().WithTcpServer("localhost").Build());
+
+            TaskCompletionSource<string> response = null;
+
+            receiverClient.ApplicationMessageReceived += (sender, args) =>
+            {
+                response?.SetResult(args.ApplicationMessage.ConvertPayloadToString());
+            };
+
+            var times = new List<TimeSpan>();
+            var stopwatch = Stopwatch.StartNew();
+
+            for (var i = 0; i < 100; i++)
+            {
+                response = new TaskCompletionSource<string>();
+                await senderClient.PublishAsync("test", DateTime.UtcNow.Ticks.ToString());
+                response.Task.GetAwaiter().GetResult();
+
+                stopwatch.Stop();
+                times.Add(stopwatch.Elapsed);
+                stopwatch.Restart();
+            }           
+        }
+    }
+}

--- a/Tests/MQTTnet.Core.Tests/RoundtripTimeTests.cs
+++ b/Tests/MQTTnet.Core.Tests/RoundtripTimeTests.cs
@@ -45,7 +45,9 @@ namespace MQTTnet.Core.Tests
                 stopwatch.Stop();
                 times.Add(stopwatch.Elapsed);
                 stopwatch.Restart();
-            }           
+            }
+
+            await server.StopAsync();
         }
     }
 }

--- a/Tests/MQTTnet.Core.Tests/TestServerExtensions.cs
+++ b/Tests/MQTTnet.Core.Tests/TestServerExtensions.cs
@@ -11,19 +11,20 @@ namespace MQTTnet.Core.Tests
         /// publishes a message with a client and waits in the server until a message with the same topic is received
         /// </summary>
         /// <returns></returns>
-        public static async Task PublishAndWaitForAsync(this IMqttClient client, IMqttServer server, MqttApplicationMessage message) 
+        public static async Task PublishAndWaitForAsync(this IMqttClient client, IMqttServer server, MqttApplicationMessage message)
         {
             var tcs = new TaskCompletionSource<object>();
 
-            EventHandler<MqttApplicationMessageReceivedEventArgs> handler = (sender, args) =>
+            void Handler(object sender, MqttApplicationMessageReceivedEventArgs args)
             {
                 if (args.ApplicationMessage.Topic == message.Topic)
                 {
                     tcs.SetResult(true);
                 }
-            };
-            server.ApplicationMessageReceived += handler;
-            
+            }
+
+            server.ApplicationMessageReceived += Handler;
+
             try
             {
                 await client.PublishAsync(message).ConfigureAwait(false);
@@ -31,7 +32,7 @@ namespace MQTTnet.Core.Tests
             }
             finally
             {
-                server.ApplicationMessageReceived -= handler;
+                server.ApplicationMessageReceived -= Handler;
             }
         }
     }

--- a/Tests/MQTTnet.TestApp.AspNetCore2/MQTTnet.TestApp.AspNetCore2.csproj
+++ b/Tests/MQTTnet.TestApp.AspNetCore2/MQTTnet.TestApp.AspNetCore2.csproj
@@ -10,8 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MQTTnet.TestApp.NetCore/MQTTnet.TestApp.NetCore.csproj
+++ b/Tests/MQTTnet.TestApp.NetCore/MQTTnet.TestApp.NetCore.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <DebugType>Full</DebugType>
-    <TargetFrameworks>netcoreapp2.0;net452;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452;net461</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
-    <DefineConstants>RELEASE;NETCOREAPP2_0</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.1|AnyCPU'">
+    <DefineConstants>RELEASE;NETCOREAPP2_1</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/MQTTnet.TestApp.UniversalWindows/MQTTnet.TestApp.UniversalWindows.csproj
+++ b/Tests/MQTTnet.TestApp.UniversalWindows/MQTTnet.TestApp.UniversalWindows.csproj
@@ -142,10 +142,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.5</Version>
+      <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>3.0.0</Version>
+      <Version>4.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
This might be a little controversial, but it worked for us to correct a problem in which messages get stuck in the managed client storage queue (and are thrown out of the regular message queue without being published!) in the case of a failed connection.  What we were seeing was that ManagedMqttClient.TryPublishQueuedMessage() was discarding a dequeued message without ever removing it from the storage queue because of an OperationCancelledException thrown by MqttClient.PublishAsync().  Tracing the code back, we found that when the connection is interrupted, after the timeout period MqttClient.InitiateDisconnect() would set the cancellation token, and the managed client would continue to try to publish, eventually calling through to MqttClient.SendAndReceiveAsync(), which would throw because the cancellation token is set.  Looking back over the code, we saw that MqttClient.PublishAsync() has a call to ThrowIfNotConnected() at the top, which told us that the intent was to not allow this function to be called after a disconnect.  But the disconnect was still pending, and the function wasn't behaving correctly in this state, so we reasoned that it's best to throw if the disconnect is pending.