### PR TITLE
Add custom WebSocket parameters

### DIFF
--- a/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using MQTTnet.Serializer;
 
 namespace MQTTnet.Client

--- a/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
@@ -113,7 +113,7 @@ namespace MQTTnet.Client
             {
                 Uri = uri,
                 RequestHeaders = parameters.RequestHeaders,
-                CookieContainer = parameters.CookierContainer
+                CookieContainer = parameters.CookieContainer
             };
 
             return this;

--- a/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
@@ -92,28 +92,13 @@ namespace MQTTnet.Client
             return this;
         }
 
-        public MqttClientOptionsBuilder WithWebSocketServer(string uri)
+        public MqttClientOptionsBuilder WithWebSocketServer(string uri, MqttClientOptionsBuilderWebSocketParameters parameters = null)
         {
-            _webSocketOptions = new MqttClientWebSocketOptions
-            {
-                Uri = uri
-            };
-
-            return this;
-        }
-
-        public MqttClientOptionsBuilder WithWebSocketServer(string uri, MqttClientOptionsBuilderWebSocketParameters parameters)
-        {
-            if(parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
             _webSocketOptions = new MqttClientWebSocketOptions
             {
                 Uri = uri,
-                RequestHeaders = parameters.RequestHeaders,
-                CookieContainer = parameters.CookieContainer
+                RequestHeaders = parameters?.RequestHeaders,
+                CookieContainer = parameters?.CookieContainer
             };
 
             return this;

--- a/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using MQTTnet.Serializer;
 
 namespace MQTTnet.Client
@@ -97,6 +99,23 @@ namespace MQTTnet.Client
             _webSocketOptions = new MqttClientWebSocketOptions
             {
                 Uri = uri
+            };
+
+            return this;
+        }
+
+        public MqttClientOptionsBuilder WithWebSocketServer(string uri, MqttClientOptionsBuilderWebSocketParameters parameters)
+        {
+            if(parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            _webSocketOptions = new MqttClientWebSocketOptions
+            {
+                Uri = uri,
+                RequestHeaders = parameters.RequestHeaders,
+                CookieContainer = parameters.CookierContainer
             };
 
             return this;

--- a/Source/MQTTnet/Client/MqttClientOptionsBuilderWebSocketParameters.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilderWebSocketParameters.cs
@@ -7,6 +7,6 @@ namespace MQTTnet.Client
     {
         public IDictionary<string, string> RequestHeaders { get; set; }
 
-        public CookieContainer CookierContainer { get; set; }
+        public CookieContainer CookieContainer { get; set; }
     }
 }

--- a/Source/MQTTnet/Client/MqttClientOptionsBuilderWebSocketParameters.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilderWebSocketParameters.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace MQTTnet.Client
+{
+    public class MqttClientOptionsBuilderWebSocketParameters
+    {
+        public IDictionary<string, string> RequestHeaders { get; set; }
+
+        public CookieContainer CookierContainer { get; set; }
+    }
+}

--- a/Source/MQTTnet/Client/MqttClientOptionsBuilderWebSocketParameters.cs
+++ b/Source/MQTTnet/Client/MqttClientOptionsBuilderWebSocketParameters.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
-using System.Text;
 
 namespace MQTTnet.Client
 {


### PR DESCRIPTION
Allows users to pass custom WebSocket parameters allowing to pass request headers and cookies.

Fixes #495 and #496 
