### PR TITLE
Don't cancel token before stop session manager

### DIFF
--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -120,10 +120,10 @@ namespace MQTTnet.Server
                 {
                     return;
                 }
-
-                _cancellationTokenSource.Cancel(false);
                 
                 _clientSessionsManager.Stop();
+                
+                _cancellationTokenSource.Cancel(false);
 
                 foreach (var adapter in _adapters)
                 {


### PR DESCRIPTION
I don't know if the order here was intended, but I had some problems in a project.
There was a test which stopped the broker and started it again after `StopAsync` was awaited.
While stopping the server there was the following exception
```
System.OperationCanceledException: The operation was canceled.
   at System.Collections.Concurrent.BlockingCollection`1.TryAddWithNoTimeValidation(T item, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at MQTTnet.Server.MqttClientSessionsManager.EnqueueApplicationMessage(MqttClientSession senderClientSession, MqttPublishPacket publishPacket)
   at MQTTnet.Server.MqttClientSession.Stop(MqttClientDisconnectType type, Boolean isInsideSession)
   at MQTTnet.Server.MqttClientSessionsManager.Stop()
   at MQTTnet.Server.MqttServer.StopAsync()
```
So `MqttClientSessionsManager.EnqueueApplicationMessage` was called because the `MqttClientSession` did have a last will message, but since the cancellation token was already canceled, this exception was thrown.

According to mqtt v5 http://docs.oasis-open.org/mqtt/mqtt/v5.0/cs02/mqtt-v5.0-cs02.html#_Toc514345312
```
3.1.2.5 Will Flag
Position: bit 2 of the Connect Flags.

If the Will Flag is set to 1 this indicates that a Will Message MUST be stored on the Server and associated with the Session [MQTT-3.1.2-7]. The Will Message consists of the Will Properties, Will Topic, and Will Payload fields in the CONNECT Payload. The Will Message MUST be published after the Network Connection is subsequently closed and either the Will Delay Interval has elapsed or the Session ends, unless the Will Message has been deleted by the Server on receipt of a DISCONNECT packet with Reason Code 0x00 (Normal disconnection) or a new Network Connection for the ClientID is opened before the Will Delay Interval has elapsed [MQTT-3.1.2-8].

Situations in which the Will Message is published include, but are not limited to:

- An I/O error or network failure detected by the Server.
- The Client fails to communicate within the Keep Alive time.
- The Client closes the Network Connection without first sending a DISCONNECT packet with a Reason Code 0x00 (Normal disconnection).
- The Server closes the Network Connection without first receiving a DISCONNECT packet with a Reason Code 0x00 (Normal disconnection).
```
I think the broker should send the last will messages.

In mqtt v3.1.1 the definition is different http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
```
If the Will Flag is set to 1 this indicates that, if the Connect request is accepted, a Will Message MUST be stored on the Server and associated with the Network Connection. The Will Message MUST be published when the Network Connection is subsequently closed unless the Will Message has been deleted by the Server on receipt of a DISCONNECT Packet [MQTT-3.1.2-8].

Situations in which the Will Message is published include, but are not limited to:

An I/O error or network failure detected by the Server.
The Client fails to communicate within the Keep Alive time.
The Client closes the Network Connection without first sending a DISCONNECT Packet.
The Server closes the Network Connection because of a protocol error.
``` 