### PR TITLE
Add extension methods that provide a simpler api for IMqttClient and IManagedMqttClient

### DIFF
--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientExtensions.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientExtensions.cs
@@ -24,7 +24,31 @@ namespace MQTTnet.Extensions.ManagedClient
             return client;
         }
 
+        public static IManagedMqttClient UseConnectedHandler(this IManagedMqttClient client, Action<MqttClientConnectedEventArgs> handler)
+        {
+            if (handler == null)
+            {
+                client.ConnectedHandler = null;
+                return client;
+            }
+
+            client.ConnectedHandler = new MqttClientConnectedHandlerDelegate(handler);
+            return client;
+        }
+
         public static IManagedMqttClient UseDisconnectedHandler(this IManagedMqttClient client, Func<MqttClientDisconnectedEventArgs, Task> handler)
+        {
+            if (handler == null)
+            {
+                client.DisconnectedHandler = null;
+                return client;
+            }
+
+            client.DisconnectedHandler = new MqttClientDisconnectedHandlerDelegate(handler);
+            return client;
+        }
+
+        public static IManagedMqttClient UseDisconnectedHandler(this IManagedMqttClient client, Action<MqttClientDisconnectedEventArgs> handler)
         {
             if (handler == null)
             {

--- a/Source/MQTTnet/Client/MqttClientExtensions.cs
+++ b/Source/MQTTnet/Client/MqttClientExtensions.cs
@@ -27,7 +27,31 @@ namespace MQTTnet.Client
             return client;
         }
 
+        public static IMqttClient UseConnectedHandler(this IMqttClient client, Action<MqttClientConnectedEventArgs> handler)
+        {
+            if (handler == null)
+            {
+                client.ConnectedHandler = null;
+                return client;
+            }
+
+            client.ConnectedHandler = new MqttClientConnectedHandlerDelegate(handler);
+            return client;
+        }
+
         public static IMqttClient UseDisconnectedHandler(this IMqttClient client, Func<MqttClientDisconnectedEventArgs, Task> handler)
+        {
+            if (handler == null)
+            {
+                client.DisconnectedHandler = null;
+                return client;
+            }
+
+            client.DisconnectedHandler = new MqttClientDisconnectedHandlerDelegate(handler);
+            return client;
+        }
+
+        public static IMqttClient UseDisconnectedHandler(this IMqttClient client, Action<MqttClientDisconnectedEventArgs> handler)
         {
             if (handler == null)
             {


### PR DESCRIPTION
This PR adds extension methods on connect/disconnect that provide a non-async/await api in cases where the handlers of connect/disconnect are not async.