### PR TITLE
using IpAddressFamily based on specified server address

### DIFF
--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using MQTTnet.Channel;
 using MQTTnet.Client;
+using System.Net;
 
 namespace MQTTnet.Implementations
 {
@@ -49,7 +50,8 @@ namespace MQTTnet.Implementations
         {
             if (_socket == null)
             {
-                _socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                var serverIp = IPAddress.Parse(_options.Server);
+                _socket = new Socket(serverIp.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
             }
 
 #if NET452 || NET461


### PR DESCRIPTION
Had an issue with this library in a private network which does not support IPv6. For some reason the address family of a socket object always defaulted to InterNetworkV6. When I set the address family explicitly to InterNetwork everything worked as expected. I think this change makes the implementation more robust.