### PR TITLE
performance improvements span based serializers

### DIFF
--- a/Source/MQTTnet.AspnetCore/Client/MqttClientConnectionContextFactory.cs
+++ b/Source/MQTTnet.AspnetCore/Client/MqttClientConnectionContextFactory.cs
@@ -21,7 +21,10 @@ namespace MQTTnet.AspNetCore.Client
                     {
                         var endpoint = new DnsEndPoint(tcpOptions.Server, tcpOptions.GetPort());
                         var tcpConnection = new TcpConnection(endpoint);
-                        return new MqttConnectionContext(new MqttPacketFormatterAdapter(options.ProtocolVersion), tcpConnection);
+
+                        var writer = new SpanBasedMqttPacketWriter();
+                        var formatter = new MqttPacketFormatterAdapter(options.ProtocolVersion, writer);
+                        return new MqttConnectionContext(formatter, tcpConnection);
                     }
                 default:
                     {

--- a/Source/MQTTnet.AspnetCore/Client/Tcp/SocketSender.cs
+++ b/Source/MQTTnet.AspnetCore/Client/Tcp/SocketSender.cs
@@ -5,6 +5,10 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 
+#if NETCOREAPP2_1
+using System.Runtime.InteropServices;
+#endif
+
 namespace MQTTnet.AspNetCore.Client.Tcp
 {
     public class SocketSender

--- a/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
+++ b/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
@@ -7,6 +7,7 @@
     <Authors />
     <PackageId />
     <LangVersion>7.2</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
+++ b/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <Product />
     <Company />
     <Authors />

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -23,9 +23,14 @@ namespace MQTTnet.AspNetCore
                 _input = Connection.Transport.Input;
                 _output = Connection.Transport.Output;
             }
+
+
+            _reader = new SpanBasedMqttPacketBodyReader();
         }
+
         private PipeReader _input;
         private PipeWriter _output;
+        private readonly SpanBasedMqttPacketBodyReader _reader;
 
         public string Endpoint => Connection.ConnectionId;
         public bool IsSecureConnection => false; // TODO: Fix detection (WS vs. WSS).
@@ -88,7 +93,7 @@ namespace MQTTnet.AspNetCore
                     {
                         if (!buffer.IsEmpty)
                         {
-                            if (PacketFormatterAdapter.TryDecode(buffer, out var packet, out consumed, out observed))
+                            if (PacketFormatterAdapter.TryDecode(_reader, buffer, out var packet, out consumed, out observed))
                             {
                                 return packet;
                             }

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -18,6 +18,8 @@ namespace MQTTnet.AspNetCore
             PacketFormatterAdapter = packetFormatterAdapter ?? throw new ArgumentNullException(nameof(packetFormatterAdapter));
             Connection = connection ?? throw new ArgumentNullException(nameof(connection));
         }
+        private PipeReader _input;
+        private PipeWriter _output;
 
         public string Endpoint => Connection.ConnectionId;
         public bool IsSecureConnection => false; // TODO: Fix detection (WS vs. WSS).
@@ -33,20 +35,21 @@ namespace MQTTnet.AspNetCore
         
         private readonly SemaphoreSlim _writerSemaphore = new SemaphoreSlim(1, 1);
 
-        public Task ConnectAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        public async Task ConnectAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             if (Connection is TcpConnection tcp && !tcp.IsConnected)
             {
-                return tcp.StartAsync();
+                await tcp.StartAsync().ConfigureAwait(false);
             }
 
-            return Task.CompletedTask;
+            _input = Connection.Transport.Input;
+            _output = Connection.Transport.Output;
         }
 
         public Task DisconnectAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
-            Connection.Transport.Input.Complete();
-            Connection.Transport.Output.Complete();
+            _input?.Complete();
+            _output?.Complete();
 
             return Task.CompletedTask;
         }
@@ -54,7 +57,6 @@ namespace MQTTnet.AspNetCore
         public async Task<MqttBasePacket> ReceivePacketAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             var input = Connection.Transport.Input;
-            var reader = new SpanBasedMqttPacketBodyReader();
 
             try
             {

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -54,6 +54,7 @@ namespace MQTTnet.AspNetCore
         public async Task<MqttBasePacket> ReceivePacketAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             var input = Connection.Transport.Input;
+            var reader = new SpanBasedMqttPacketBodyReader();
 
             try
             {

--- a/Source/MQTTnet.AspnetCore/MqttConnectionHandler.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionHandler.cs
@@ -21,7 +21,9 @@ namespace MQTTnet.AspNetCore
                 transferFormatFeature.ActiveFormat = TransferFormat.Binary;
             }
 
-            using (var adapter = new MqttConnectionContext(new MqttPacketFormatterAdapter(), connection))
+            var writer = new SpanBasedMqttPacketWriter();
+            var formatter = new MqttPacketFormatterAdapter(writer);
+            using (var adapter = new MqttConnectionContext(formatter, connection))
             {
                 var args = new MqttServerAdapterClientAcceptedEventArgs(adapter);
                 ClientAcceptedHandler?.Invoke(args);

--- a/Source/MQTTnet.AspnetCore/MqttWebSocketServerAdapter.cs
+++ b/Source/MQTTnet.AspnetCore/MqttWebSocketServerAdapter.cs
@@ -43,8 +43,10 @@ namespace MQTTnet.AspNetCore
             var isSecureConnection = clientCertificate != null;
             clientCertificate?.Dispose();
 
+            var writer = new SpanBasedMqttPacketWriter();
+            var formatter = new MqttPacketFormatterAdapter(writer);
             var channel = new MqttWebSocketChannel(webSocket, endpoint, isSecureConnection);
-            var channelAdapter = new MqttChannelAdapter(channel, new MqttPacketFormatterAdapter(), _logger.CreateChildLogger(nameof(MqttWebSocketServerAdapter)));
+            var channelAdapter = new MqttChannelAdapter(channel, formatter, new MqttNetLogger().CreateChildLogger(nameof(MqttWebSocketServerAdapter)));
 
             var eventArgs = new MqttServerAdapterClientAcceptedEventArgs(channelAdapter);
             ClientAcceptedHandler?.Invoke(eventArgs);

--- a/Source/MQTTnet.AspnetCore/MqttWebSocketServerAdapter.cs
+++ b/Source/MQTTnet.AspnetCore/MqttWebSocketServerAdapter.cs
@@ -46,7 +46,7 @@ namespace MQTTnet.AspNetCore
             var writer = new SpanBasedMqttPacketWriter();
             var formatter = new MqttPacketFormatterAdapter(writer);
             var channel = new MqttWebSocketChannel(webSocket, endpoint, isSecureConnection);
-            var channelAdapter = new MqttChannelAdapter(channel, formatter, new MqttNetLogger().CreateChildLogger(nameof(MqttWebSocketServerAdapter)));
+            var channelAdapter = new MqttChannelAdapter(channel, formatter, _logger.CreateChildLogger(nameof(MqttWebSocketServerAdapter)));
 
             var eventArgs = new MqttServerAdapterClientAcceptedEventArgs(channelAdapter);
             ClientAcceptedHandler?.Invoke(eventArgs);

--- a/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
+++ b/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
@@ -42,7 +42,7 @@ namespace MQTTnet.AspNetCore
 
             var receivedMqttPacket = new ReceivedMqttPacket(fixedheader, reader, buffer.Length + 2);
 
-            if (!formatter.ProtocolVersion.HasValue)
+            if (formatter.ProtocolVersion == MqttProtocolVersion.Unknown)
             {
                 formatter.DetectProtocolVersion(receivedMqttPacket);
             }

--- a/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
+++ b/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
@@ -40,7 +40,14 @@ namespace MQTTnet.AspNetCore
             var reader = new SpanBasedMqttPacketBodyReader();
             reader.SetBuffer(buffer);
 
-            packet = formatter.Decode(new ReceivedMqttPacket(fixedheader, reader, buffer.Length + 2));
+            var receivedMqttPacket = new ReceivedMqttPacket(fixedheader, reader, buffer.Length + 2);
+
+            if (!formatter.ProtocolVersion.HasValue)
+            {
+                formatter.DetectProtocolVersion(receivedMqttPacket);
+            }
+
+            packet = formatter.Decode(receivedMqttPacket);
             consumed = bodySlice.End;
             observed = bodySlice.End;
             return true;

--- a/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
+++ b/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
@@ -9,7 +9,7 @@ namespace MQTTnet.AspNetCore
 {
     public static class ReaderExtensions
     {
-        public static bool TryDecode(this MqttPacketFormatterAdapter formatter, in ReadOnlySequence<byte> input, out MqttBasePacket packet, out SequencePosition consumed, out SequencePosition observed)
+        public static bool TryDecode(this MqttPacketFormatterAdapter formatter, SpanBasedMqttPacketBodyReader reader, in ReadOnlySequence<byte> input, out MqttBasePacket packet, out SequencePosition consumed, out SequencePosition observed)
         {
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
 
@@ -36,8 +36,6 @@ namespace MQTTnet.AspNetCore
 
             var bodySlice = copy.Slice(0, bodyLength);
             var buffer = bodySlice.GetMemory();
-
-            var reader = new SpanBasedMqttPacketBodyReader();
             reader.SetBuffer(buffer);
 
             var receivedMqttPacket = new ReceivedMqttPacket(fixedheader, reader, buffer.Length + 2);

--- a/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
+++ b/Source/MQTTnet.AspnetCore/ReaderExtensions.cs
@@ -35,18 +35,22 @@ namespace MQTTnet.AspNetCore
             }
 
             var bodySlice = copy.Slice(0, bodyLength);
-            var buffer = bodySlice.GetArray();
-            packet = formatter.Decode(new ReceivedMqttPacket(fixedheader, new MqttPacketBodyReader(buffer, 0, buffer.Length), buffer.Length + 2));
+            var buffer = bodySlice.GetMemory();
+
+            var reader = new SpanBasedMqttPacketBodyReader();
+            reader.SetBuffer(buffer);
+
+            packet = formatter.Decode(new ReceivedMqttPacket(fixedheader, reader, buffer.Length + 2));
             consumed = bodySlice.End;
             observed = bodySlice.End;
             return true;
         }
 
-        private static byte[] GetArray(this in ReadOnlySequence<byte> input)
+        private static ReadOnlyMemory<byte> GetMemory(this in ReadOnlySequence<byte> input)
         {
             if (input.IsSingleSegment)
             {
-                return input.First.Span.ToArray();
+                return input.First;
             }
 
             // Should be rare
@@ -62,7 +66,7 @@ namespace MQTTnet.AspNetCore
             var index = 1;
             result = 0;
 
-            var temp = input.Slice(0, Math.Min(5, input.Length)).GetArray();
+            var temp = input.Slice(0, Math.Min(5, input.Length)).GetMemory();
 
             do
             {
@@ -70,13 +74,13 @@ namespace MQTTnet.AspNetCore
                 {
                     return false;
                 }
-                encodedByte = temp[index];
+                encodedByte = temp.Span[index];
                 index++;
 
                 value += (byte)(encodedByte & 127) * multiplier;
                 if (multiplier > 128 * 128 * 128)
                 {
-                    throw new MqttProtocolViolationException($"Remaining length is invalid (Data={string.Join(",", temp.AsSpan(1, index).ToArray())}).");
+                    throw new MqttProtocolViolationException($"Remaining length is invalid (Data={string.Join(",", temp.Slice(1, index).ToArray())}).");
                 }
 
                 multiplier *= 128;

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
@@ -1,0 +1,104 @@
+﻿using MQTTnet.Formatter;
+using System;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace MQTTnet.AspNetCore
+{
+    public class SpanBasedMqttPacketBodyReader : IMqttPacketBodyReader
+    {
+        private ReadOnlyMemory<byte> _buffer;
+        private int _offset;
+        
+        public void SetBuffer(ReadOnlyMemory<byte> buffer)
+        {
+            _buffer = buffer;
+            _offset = 0;
+        }
+
+        public ulong Length => (ulong)_buffer.Length;
+
+        public bool EndOfStream => _buffer.Length.Equals(_offset);
+        
+        public ulong Offset => (ulong)_offset;
+
+        public byte ReadByte()
+        {
+            ValidateReceiveBuffer(1);
+            return _buffer.Span[_offset++];
+        }
+
+        public byte[] ReadRemainingData()
+        {
+            return _buffer.ToArray();
+        }
+
+        public ushort ReadUInt16()
+        {
+            ValidateReceiveBuffer(2);
+
+            var result = BinaryPrimitives.ReadUInt16BigEndian(_buffer.Span);
+            _offset += 2;
+            return result;
+        }
+
+        public byte[] ReadWithLengthPrefix()
+        {
+            return ReadSegmentWithLengthPrefix().ToArray();
+        }
+
+        private ReadOnlyMemory<byte> ReadSegmentWithLengthPrefix()
+        {
+            var length = ReadUInt16();
+
+            ValidateReceiveBuffer(length);
+
+            var result = _buffer.Slice(_offset, length);
+            _offset += length;
+            return result;
+        }
+
+        private void ValidateReceiveBuffer(ushort length)
+        {
+            if (_buffer.Length < _offset + length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(_buffer), $"expected at least {_offset + length} bytes but there are only {_buffer.Length} bytes");
+            }
+        }
+
+        public unsafe string ReadStringWithLengthPrefix()
+        {
+            var buffer = ReadSegmentWithLengthPrefix();
+            fixed (byte* bytes = &buffer.Span.GetPinnableReference())
+            {
+                var result = Encoding.UTF8.GetString(bytes, buffer.Length);
+                return result;
+            }
+        }
+
+        public ushort ReadTwoByteInteger()
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint ReadFourByteInteger()
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint ReadVariableLengthInteger()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ReadBoolean()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Seek(ulong position)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
@@ -30,7 +30,7 @@ namespace MQTTnet.AspNetCore
 
         public byte[] ReadRemainingData()
         {
-            return _buffer.ToArray();
+            return _buffer.Slice(_offset).ToArray();
         }
 
         public ushort ReadUInt16()
@@ -47,13 +47,13 @@ namespace MQTTnet.AspNetCore
             return ReadSegmentWithLengthPrefix().ToArray();
         }
 
-        private ReadOnlyMemory<byte> ReadSegmentWithLengthPrefix()
+        private ReadOnlySpan<byte> ReadSegmentWithLengthPrefix()
         {
             var length = ReadUInt16();
 
             ValidateReceiveBuffer(length);
 
-            var result = _buffer.Slice(_offset, length);
+            var result = _buffer.Slice(_offset, length).Span;
             _offset += length;
             return result;
         }
@@ -69,7 +69,7 @@ namespace MQTTnet.AspNetCore
         public unsafe string ReadStringWithLengthPrefix()
         {
             var buffer = ReadSegmentWithLengthPrefix();
-            fixed (byte* bytes = &buffer.Span.GetPinnableReference())
+            fixed (byte* bytes = &buffer.GetPinnableReference())
             {
                 var result = Encoding.UTF8.GetString(bytes, buffer.Length);
                 return result;

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
@@ -51,6 +51,11 @@ namespace MQTTnet.AspNetCore
         public unsafe string ReadStringWithLengthPrefix()
         {
             var buffer = ReadSegmentWithLengthPrefix();
+            if (buffer.Length == 0)
+            {
+                return string.Empty;
+            }
+
             fixed (byte* bytes = &buffer.GetPinnableReference())
             {
                 var result = Encoding.UTF8.GetString(bytes, buffer.Length);

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
@@ -1,4 +1,5 @@
-﻿using MQTTnet.Formatter;
+﻿using MQTTnet.Exceptions;
+using MQTTnet.Formatter;
 using System;
 using System.Buffers.Binary;
 using System.Text;
@@ -32,13 +33,6 @@ namespace MQTTnet.AspNetCore
             return _buffer.Slice(_offset).ToArray();
         }
 
-        public ushort ReadUInt16()
-        {
-            var result = BinaryPrimitives.ReadUInt16BigEndian(_buffer.Span.Slice(_offset));
-            _offset += 2;
-            return result;
-        }
-
         public byte[] ReadWithLengthPrefix()
         {
             return ReadSegmentWithLengthPrefix().ToArray();
@@ -66,27 +60,60 @@ namespace MQTTnet.AspNetCore
 
         public ushort ReadTwoByteInteger()
         {
-            throw new NotImplementedException();
+            var result = BinaryPrimitives.ReadUInt16BigEndian(_buffer.Span.Slice(_offset));
+            _offset += 2;
+            return result;
         }
 
         public uint ReadFourByteInteger()
         {
-            throw new NotImplementedException();
+            var result = BinaryPrimitives.ReadUInt32BigEndian(_buffer.Span.Slice(_offset));
+            _offset += 4;
+            return result;
         }
 
         public uint ReadVariableLengthInteger()
         {
-            throw new NotImplementedException();
+            var multiplier = 1;
+            var value = 0U;
+            byte encodedByte;
+
+            do
+            {
+                encodedByte = ReadByte();
+                value += (uint)((encodedByte & 127) * multiplier);
+
+                if (multiplier > 2097152)
+                {
+                    throw new MqttProtocolViolationException("Variable length integer is invalid.");
+                }
+
+                multiplier *= 128;
+            } while ((encodedByte & 128) != 0);
+
+            return value;
         }
 
         public bool ReadBoolean()
         {
-            throw new NotImplementedException();
+            var buffer = ReadByte();
+
+            if (buffer == 0)
+            {
+                return false;
+            }
+
+            if (buffer == 1)
+            {
+                return true;
+            }
+
+            throw new MqttProtocolViolationException("Boolean values can be 0 or 1 only.");
         }
 
         public void Seek(ulong position)
         {
-            throw new NotImplementedException();
+            _offset = (int)position;
         }
     }
 }

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketWriter.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketWriter.cs
@@ -1,0 +1,147 @@
+﻿using MQTTnet.Formatter;
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace MQTTnet.AspNetCore
+{
+    public class SpanBasedMqttPacketWriter : IMqttPacketWriter
+    {
+        private readonly ArrayPool<byte> _pool;
+
+        public SpanBasedMqttPacketWriter()
+        {
+            _pool = ArrayPool<byte>.Create();
+            
+        }
+
+        private byte[] _buffer;
+        private int _position;
+
+        public int Length { get; set; }
+
+        public void FreeBuffer()
+        {
+            _pool.Return(_buffer);
+        }
+
+        public byte[] GetBuffer()
+        {
+            return _buffer;
+        }
+
+        public void Reset(int v)
+        {
+            _buffer = _pool.Rent(1500);
+            Length = v;
+            _position = v;
+        }
+
+        public void Seek(int v)
+        {
+            _position = v;
+        }
+
+        public void Write(byte value)
+        {
+            GrowIfNeeded(1);
+            _buffer[_position] = value;
+            Commit(1);
+        }
+
+        public void Write(ushort value)
+        {
+            GrowIfNeeded(2);
+
+            BinaryPrimitives.WriteUInt16BigEndian(_buffer.AsSpan(_position), value);
+            Commit(2);
+        }
+
+        public void Write(IMqttPacketWriter propertyWriter)
+        {
+            if (propertyWriter is SpanBasedMqttPacketWriter writer)
+            {
+                GrowIfNeeded(1);
+            }
+
+            throw new InvalidOperationException($"{nameof(propertyWriter)} must be of type {typeof(SpanBasedMqttPacketWriter).Name}");
+        }
+
+        public void Write(byte[] payload, int start, int length)
+        {
+            GrowIfNeeded(length);
+
+            payload.AsSpan(start, length).CopyTo(_buffer.AsSpan(_position));
+            Commit(length);
+        }
+
+        public void WriteVariableLengthInteger(uint value)
+        {
+            GrowIfNeeded(4);
+            
+            var x = value;
+            do
+            {
+                var encodedByte = x % 128;
+                x = x / 128;
+                if (x > 0)
+                {
+                    encodedByte = encodedByte | 128;
+                }
+
+                _buffer[_position] = (byte)encodedByte;
+                Commit(1);
+            } while (x > 0);
+        }
+
+        public void WriteWithLengthPrefix(string value)
+        {
+            var bytesLength = Encoding.UTF8.GetByteCount(value ?? string.Empty);
+            GrowIfNeeded(bytesLength + 2);
+
+            Write((ushort)bytesLength);
+            Encoding.UTF8.GetBytes(value ?? string.Empty, 0, value?.Length ?? 0, _buffer, _position);
+            Commit(bytesLength);
+        }
+
+        public void WriteWithLengthPrefix(byte[] payload)
+        {
+            GrowIfNeeded(payload.Length + 2);
+            
+            Write((ushort)payload.Length);
+            payload.CopyTo(_buffer, _position);
+            Commit(payload.Length);
+        }
+
+        private void Commit(int count)
+        {
+            if (_position == Length)
+            {
+                Length += count;
+            }
+
+            _position += count;
+        }
+
+        private void GrowIfNeeded(int requiredAdditional) 
+        {
+            var requiredTotal = _position + requiredAdditional;
+            if (_buffer.Length >= requiredTotal)
+            {
+                return;
+            }
+
+            var newBufferLength = _buffer.Length;
+            while (newBufferLength < requiredTotal)
+            {
+                newBufferLength *= 2;
+            }
+
+            var newBuffer = _pool.Rent(newBufferLength);
+            Array.Copy(_buffer, newBuffer, _buffer.Length);
+            _pool.Return(_buffer);
+            _buffer = newBuffer;
+        }
+    }
+}

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketWriter.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketWriter.cs
@@ -60,12 +60,11 @@ namespace MQTTnet.AspNetCore
 
         public void Write(IMqttPacketWriter propertyWriter)
         {
-            if (propertyWriter is SpanBasedMqttPacketWriter writer)
-            {
-                GrowIfNeeded(1);
-            }
+            if (propertyWriter == null) throw new ArgumentNullException(nameof(propertyWriter));
 
-            throw new InvalidOperationException($"{nameof(propertyWriter)} must be of type {typeof(SpanBasedMqttPacketWriter).Name}");
+            GrowIfNeeded(propertyWriter.Length);
+            Write(propertyWriter.GetBuffer(), 0, propertyWriter.Length);
+            Commit(propertyWriter.Length);
         }
 
         public void Write(byte[] payload, int start, int length)

--- a/Source/MQTTnet/Adapter/ReceivedMqttPacket.cs
+++ b/Source/MQTTnet/Adapter/ReceivedMqttPacket.cs
@@ -4,16 +4,16 @@ namespace MQTTnet.Adapter
 {
     public class ReceivedMqttPacket
     {
-        public ReceivedMqttPacket(byte fixedHeader, MqttPacketBodyReader body, int totalLength)
+        public ReceivedMqttPacket(byte fixedHeader, IMqttPacketBodyReader body, int totalLength)
         {
             FixedHeader = fixedHeader;
             Body = body;
             TotalLength = totalLength;
         }
 
-        public byte FixedHeader { get; }
+        public byte FixedHeader { get; set; }
 
-        public MqttPacketBodyReader Body { get; }
+        public IMqttPacketBodyReader Body { get; }
 
         public int TotalLength { get; }
     }

--- a/Source/MQTTnet/Formatter/IMqttPacketBodyReader.cs
+++ b/Source/MQTTnet/Formatter/IMqttPacketBodyReader.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace MQTTnet.Formatter
+{
+    public interface IMqttPacketBodyReader
+    {
+        ulong Length { get; }
+
+        ulong Offset { get; }
+
+        bool EndOfStream { get; }
+
+        byte ReadByte();
+
+        byte[] ReadRemainingData();
+
+        ushort ReadTwoByteInteger();
+
+        string ReadStringWithLengthPrefix();
+
+        byte[] ReadWithLengthPrefix();
+
+        uint ReadFourByteInteger();
+
+        uint ReadVariableLengthInteger();
+
+        bool ReadBoolean();
+
+        void Seek(ulong position);
+    }
+}

--- a/Source/MQTTnet/Formatter/IMqttPacketWriter.cs
+++ b/Source/MQTTnet/Formatter/IMqttPacketWriter.cs
@@ -1,0 +1,20 @@
+﻿namespace MQTTnet.Formatter
+{
+    public interface IMqttPacketWriter
+    {
+        int Length { get; }
+
+        void WriteWithLengthPrefix(string value);
+        void Write(byte returnCode);
+        void WriteWithLengthPrefix(byte[] payload);
+        void Write(ushort keepAlivePeriod);
+
+        void Write(IMqttPacketWriter propertyWriter);
+        void WriteVariableLengthInteger(uint length);
+        void Write(byte[] payload, int v, int length);
+        void Reset(int v);
+        void Seek(int v);
+        void FreeBuffer();
+        byte[] GetBuffer();
+    }
+}

--- a/Source/MQTTnet/Formatter/MqttPacketBodyReader.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketBodyReader.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using MQTTnet.Exceptions;
 
 namespace MQTTnet.Formatter
 {
-    public class MqttPacketBodyReader
+    public class MqttPacketBodyReader : IMqttPacketBodyReader
     {
         private readonly byte[] _buffer;
         private readonly ulong _initialOffset;
@@ -68,9 +69,9 @@ namespace MQTTnet.Formatter
             throw new MqttProtocolViolationException("Boolean values can be 0 or 1 only.");
         }
 
-        public ArraySegment<byte> ReadRemainingData()
+        public byte[] ReadRemainingData()
         {
-            return new ArraySegment<byte>(_buffer, (int)Offset, (int)(_length - Offset));
+            return new ArraySegment<byte>(_buffer, (int)Offset, (int)(_length - Offset)).ToArray();
         }
 
         public ushort ReadTwoByteInteger()
@@ -95,7 +96,12 @@ namespace MQTTnet.Formatter
             return (uint)(byte0 << 24 | byte1 << 16 | byte2 << 8 | byte3);
         }
 
-        public ArraySegment<byte> ReadWithLengthPrefix()
+        public byte[] ReadWithLengthPrefix()
+        {
+            return ReadSegmentWithLengthPrefix().ToArray();
+        }
+
+        private ArraySegment<byte> ReadSegmentWithLengthPrefix()
         {
             var length = ReadTwoByteInteger();
 
@@ -140,7 +146,7 @@ namespace MQTTnet.Formatter
 
         public string ReadStringWithLengthPrefix()
         {
-            var buffer = ReadWithLengthPrefix();
+            var buffer = ReadSegmentWithLengthPrefix();
             return Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
         }
     }

--- a/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
@@ -12,13 +12,25 @@ namespace MQTTnet.Formatter
         private IMqttPacketFormatter _formatter;
 
         public MqttPacketFormatterAdapter()
+            : this(new MqttPacketWriter())
+        {
+        }
+               
+        public MqttPacketFormatterAdapter(MqttProtocolVersion protocolVersion)
+            : this(protocolVersion, new MqttPacketWriter())
         {
         }
 
-        public MqttPacketFormatterAdapter(MqttProtocolVersion protocolVersion)
+        public MqttPacketFormatterAdapter(MqttProtocolVersion protocolVersion, IMqttPacketWriter writer)
+            : this(writer)
         {
             UseProtocolVersion(protocolVersion);
         }
+
+        public MqttPacketFormatterAdapter(IMqttPacketWriter writer)
+        {
+            Writer = writer;
+        }        
 
         public MqttProtocolVersion ProtocolVersion { get; private set; } = MqttProtocolVersion.Unknown;
 
@@ -31,6 +43,8 @@ namespace MQTTnet.Formatter
                 return _formatter.DataConverter;
             }
         }
+                
+        public IMqttPacketWriter Writer { get; }
 
         public ArraySegment<byte> Encode(MqttBasePacket packet)
         {
@@ -80,20 +94,20 @@ namespace MQTTnet.Formatter
             {
                 case MqttProtocolVersion.V500:
                     {
-                        _formatter = new MqttV500PacketFormatter();
+                        _formatter = new MqttV500PacketFormatter(Writer);
                         break;
                     }
 
                 case MqttProtocolVersion.V311:
                     {
-                        _formatter = new MqttV311PacketFormatter();
+                        _formatter = new MqttV311PacketFormatter(Writer);
                         break;
                     }
 
                 case MqttProtocolVersion.V310:
                     {
 
-                        _formatter = new MqttV310PacketFormatter();
+                        _formatter = new MqttV310PacketFormatter(Writer);
                         break;
                     }
                     

--- a/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
@@ -89,28 +89,30 @@ namespace MQTTnet.Formatter
             }
 
             ProtocolVersion = protocolVersion;
+            _formatter = GetMqttPacketFormatter(protocolVersion, Writer);
+        }
 
+        public static IMqttPacketFormatter GetMqttPacketFormatter(MqttProtocolVersion protocolVersion, IMqttPacketWriter writer)
+        {
+            if (protocolVersion == MqttProtocolVersion.Unknown)
+            {
+                throw new InvalidOperationException("MQTT protocol version is invalid.");
+            }
+            
             switch (protocolVersion)
             {
                 case MqttProtocolVersion.V500:
                     {
-                        _formatter = new MqttV500PacketFormatter(Writer);
-                        break;
+                        return new MqttV500PacketFormatter(writer);
                     }
-
                 case MqttProtocolVersion.V311:
                     {
-                        _formatter = new MqttV311PacketFormatter(Writer);
-                        break;
+                        return new MqttV311PacketFormatter(writer);
                     }
-
                 case MqttProtocolVersion.V310:
                     {
-
-                        _formatter = new MqttV310PacketFormatter(Writer);
-                        break;
+                        return new MqttV310PacketFormatter(writer);
                     }
-                    
                 default:
                     {
                         throw new NotSupportedException();

--- a/Source/MQTTnet/Formatter/MqttPacketWriter.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketWriter.cs
@@ -11,7 +11,7 @@ namespace MQTTnet.Formatter
     /// same as for the original MemoryStream in .net. Also this implementation allows accessing the internal
     /// buffer for all platforms and .net framework versions (which is not available at the regular MemoryStream).
     /// </summary>
-    public class MqttPacketWriter
+    public class MqttPacketWriter : IMqttPacketWriter
     {
         private static readonly ArraySegment<byte> ZeroVariableLengthIntegerArray = new ArraySegment<byte>(new byte[1], 0, 1);
         private static readonly ArraySegment<byte> ZeroTwoByteIntegerArray = new ArraySegment<byte>(new byte[2], 0, 2);
@@ -31,6 +31,19 @@ namespace MQTTnet.Formatter
             var fixedHeader = (int)packetType << 4;
             fixedHeader |= flags;
             return (byte)fixedHeader;
+        }
+
+        public static int GetLengthOfVariableInteger(uint value)
+        {
+            var result = 0;
+            var x = value;
+            do
+            {
+                x = x / 128;
+                result++;
+            } while (x > 0);
+
+            return result;
         }
 
         public static ArraySegment<byte> EncodeVariableLengthInteger(uint value)
@@ -129,16 +142,21 @@ namespace MQTTnet.Formatter
             IncreasePosition(count);
         }
 
-        public void Write(MqttPacketWriter propertyWriter)
+        public void Write(IMqttPacketWriter propertyWriter)
         {
             if (propertyWriter == null) throw new ArgumentNullException(nameof(propertyWriter));
 
-            if (propertyWriter.Length == 0)
+            if (propertyWriter is MqttPacketWriter writer)
             {
-                return;
+                if (writer.Length == 0)
+                {
+                    return;
+                }
+
+                Write(writer._buffer, 0, writer.Length);
             }
 
-            Write(propertyWriter._buffer, 0, propertyWriter.Length);
+            throw new InvalidOperationException($"{nameof(propertyWriter)} must be of type {typeof(MqttPacketWriter).Name}");
         }
 
         public void Reset(int length)

--- a/Source/MQTTnet/Formatter/MqttPacketWriter.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketWriter.cs
@@ -154,6 +154,7 @@ namespace MQTTnet.Formatter
                 }
 
                 Write(writer._buffer, 0, writer.Length);
+                return;
             }
 
             throw new InvalidOperationException($"{nameof(propertyWriter)} must be of type {typeof(MqttPacketWriter).Name}");

--- a/Source/MQTTnet/Formatter/V3/MqttV310PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV310PacketFormatter.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using MQTTnet.Adapter;
 using MQTTnet.Exceptions;
-using MQTTnet.Internal;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 
@@ -100,7 +99,7 @@ namespace MQTTnet.Formatter.V3
             }
         }
 
-        private static MqttBasePacket DecodeUnsubAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeUnsubAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -110,7 +109,7 @@ namespace MQTTnet.Formatter.V3
             };
         }
 
-        private static MqttBasePacket DecodePubCompPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubCompPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -120,7 +119,7 @@ namespace MQTTnet.Formatter.V3
             };
         }
 
-        private static MqttBasePacket DecodePubRelPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubRelPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -130,7 +129,7 @@ namespace MQTTnet.Formatter.V3
             };
         }
 
-        private static MqttBasePacket DecodePubRecPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubRecPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -140,7 +139,7 @@ namespace MQTTnet.Formatter.V3
             };
         }
 
-        private static MqttBasePacket DecodePubAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -150,7 +149,7 @@ namespace MQTTnet.Formatter.V3
             };
         }
 
-        private static MqttBasePacket DecodeUnsubscribePacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeUnsubscribePacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -167,7 +166,7 @@ namespace MQTTnet.Formatter.V3
             return packet;
         }
 
-        private static MqttBasePacket DecodeSubscribePacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeSubscribePacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -223,7 +222,7 @@ namespace MQTTnet.Formatter.V3
             return packet;
         }
 
-        private MqttBasePacket DecodeConnectPacket(MqttPacketBodyReader body)
+        private MqttBasePacket DecodeConnectPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -264,7 +263,7 @@ namespace MQTTnet.Formatter.V3
                 packet.WillMessage = new MqttApplicationMessage
                 {
                     Topic = body.ReadStringWithLengthPrefix(),
-                    Payload = body.ReadWithLengthPrefix().ToArray(),
+                    Payload = body.ReadWithLengthPrefix(),
                     QualityOfServiceLevel = (MqttQualityOfServiceLevel)willQoS,
                     Retain = willRetain
                 };
@@ -284,7 +283,7 @@ namespace MQTTnet.Formatter.V3
             return packet;
         }
 
-        private static MqttBasePacket DecodeSubAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeSubAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -301,7 +300,7 @@ namespace MQTTnet.Formatter.V3
             return packet;
         }
 
-        protected virtual MqttBasePacket DecodeConnAckPacket(MqttPacketBodyReader body)
+        protected virtual MqttBasePacket DecodeConnAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -577,7 +576,7 @@ namespace MQTTnet.Formatter.V3
         }
 
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
-        protected static void ThrowIfBodyIsEmpty(MqttPacketBodyReader body)
+        protected static void ThrowIfBodyIsEmpty(IMqttPacketBodyReader body)
         {
             if (body == null || body.Length == 0)
             {

--- a/Source/MQTTnet/Formatter/V3/MqttV311PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV311PacketFormatter.cs
@@ -82,7 +82,7 @@ namespace MQTTnet.Formatter.V3
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.ConnAck);
         }
 
-        protected override MqttBasePacket DecodeConnAckPacket(MqttPacketBodyReader body)
+        protected override MqttBasePacket DecodeConnAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 

--- a/Source/MQTTnet/Formatter/V3/MqttV311PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV311PacketFormatter.cs
@@ -6,7 +6,17 @@ namespace MQTTnet.Formatter.V3
 {
     public class MqttV311PacketFormatter : MqttV310PacketFormatter
     {
-        protected override byte EncodeConnectPacket(MqttConnectPacket packet, MqttPacketWriter packetWriter)
+        public MqttV311PacketFormatter()
+            : base()
+        {
+        }
+
+        public MqttV311PacketFormatter(IMqttPacketWriter packetWriter)
+            : base(packetWriter)
+        {
+        }
+
+        protected override byte EncodeConnectPacket(MqttConnectPacket packet, IMqttPacketWriter packetWriter)
         {
             ValidateConnectPacket(packet);
 
@@ -68,7 +78,7 @@ namespace MQTTnet.Formatter.V3
             return MqttPacketWriter.BuildFixedHeader(MqttControlPacketType.Connect);
         }
 
-        protected override byte EncodeConnAckPacket(MqttConnAckPacket packet, MqttPacketWriter packetWriter)
+        protected override byte EncodeConnAckPacket(MqttConnAckPacket packet, IMqttPacketWriter packetWriter)
         {
             byte connectAcknowledgeFlags = 0x0;
             if (packet.IsSessionPresent)

--- a/Source/MQTTnet/Formatter/V5/MqttV500PacketDecoder.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV500PacketDecoder.cs
@@ -41,7 +41,7 @@ namespace MQTTnet.Formatter.V5
             }
         }
 
-        private static MqttBasePacket DecodeConnectPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeConnectPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -134,7 +134,7 @@ namespace MQTTnet.Formatter.V5
             if (packet.WillMessage != null)
             {
                 packet.WillMessage.Topic = body.ReadStringWithLengthPrefix();
-                packet.WillMessage.Payload = body.ReadWithLengthPrefix().ToArray();
+                packet.WillMessage.Payload = body.ReadWithLengthPrefix();
             }
 
             if (usernameFlag)
@@ -150,7 +150,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeConnAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeConnAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -239,7 +239,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeDisconnectPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeDisconnectPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -277,7 +277,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeSubscribePacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeSubscribePacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -327,7 +327,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeSubAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeSubAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -363,7 +363,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeUnsubscribePacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeUnsubscribePacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -394,7 +394,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeUnsubAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeUnsubAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -440,7 +440,7 @@ namespace MQTTnet.Formatter.V5
             return new MqttPingRespPacket();
         }
 
-        private static MqttBasePacket DecodePublishPacket(byte header, MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePublishPacket(byte header, IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -511,7 +511,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodePubAckPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubAckPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -549,7 +549,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodePubRecPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubRecPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -587,7 +587,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodePubRelPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubRelPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -625,7 +625,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodePubCompPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodePubCompPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -663,7 +663,7 @@ namespace MQTTnet.Formatter.V5
             return packet;
         }
 
-        private static MqttBasePacket DecodeAuthPacket(MqttPacketBodyReader body)
+        private static MqttBasePacket DecodeAuthPacket(IMqttPacketBodyReader body)
         {
             ThrowIfBodyIsEmpty(body);
 
@@ -709,7 +709,7 @@ namespace MQTTnet.Formatter.V5
         }
 
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
-        private static void ThrowIfBodyIsEmpty(MqttPacketBodyReader body)
+        private static void ThrowIfBodyIsEmpty(IMqttPacketBodyReader body)
         {
             if (body == null || body.Length == 0)
             {

--- a/Source/MQTTnet/Formatter/V5/MqttV500PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV500PacketFormatter.cs
@@ -6,8 +6,18 @@ namespace MQTTnet.Formatter.V5
 {
     public class MqttV500PacketFormatter : IMqttPacketFormatter
     {
-        private readonly MqttV500PacketEncoder _encoder = new MqttV500PacketEncoder();
+        private readonly MqttV500PacketEncoder _encoder;
         private readonly MqttV500PacketDecoder _decoder = new MqttV500PacketDecoder();
+
+        public MqttV500PacketFormatter()
+        {
+            _encoder = new MqttV500PacketEncoder();
+        }
+
+        public MqttV500PacketFormatter(IMqttPacketWriter writer)
+        {
+            _encoder = new MqttV500PacketEncoder(writer);
+        }
 
         public IMqttDataConverter DataConverter { get; } = new MqttV500DataConverter();
         

--- a/Source/MQTTnet/Formatter/V5/MqttV500PropertiesReader.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV500PropertiesReader.cs
@@ -9,11 +9,11 @@ namespace MQTTnet.Formatter.V5
 {
     public class MqttV500PropertiesReader
     {
-        private readonly MqttPacketBodyReader _body;
+        private readonly IMqttPacketBodyReader _body;
         private readonly uint _length;
         private readonly ulong _targetOffset;
 
-        public MqttV500PropertiesReader(MqttPacketBodyReader body)
+        public MqttV500PropertiesReader(IMqttPacketBodyReader body)
         {
             _body = body ?? throw new ArgumentNullException(nameof(body));
 
@@ -75,7 +75,7 @@ namespace MQTTnet.Formatter.V5
 
         public byte[] ReadAuthenticationData()
         {
-            return _body.ReadWithLengthPrefix().ToArray();
+            return _body.ReadWithLengthPrefix();
         }
 
         public bool? ReadRetainAvailable()
@@ -165,7 +165,7 @@ namespace MQTTnet.Formatter.V5
 
         public byte[] ReadCorrelationData()
         {
-            return _body.ReadWithLengthPrefix().ToArray();
+            return _body.ReadWithLengthPrefix();
         }
 
         public string ReadContentType()

--- a/Source/MQTTnet/Formatter/V5/MqttV500PropertiesWriter.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV500PropertiesWriter.cs
@@ -63,7 +63,7 @@ namespace MQTTnet.Formatter.V5
             Write(MqttPropertyId.AuthenticationMethod, value);
         }
 
-        public void WriteToPacket(MqttPacketWriter packetWriter)
+        public void WriteToPacket(IMqttPacketWriter packetWriter)
         {
             if (packetWriter == null) throw new ArgumentNullException(nameof(packetWriter));
 

--- a/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
+++ b/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Source\MQTTnet.AspnetCore\MQTTnet.AspNetCore.csproj" />
-    <ProjectReference Include="..\..\Source\MQTTnet\MQTTnet.csproj" />
+    <ProjectReference Include="..\MQTTnet.Core.Tests\MQTTnet.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/MQTTnet.AspNetCore.Tests/MqttPacketSerializerTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/MqttPacketSerializerTests.cs
@@ -13,5 +13,10 @@ namespace MQTTnet.AspNetCore.Tests
             result.SetBuffer(data);
             return result;
         }
+
+        protected override IMqttPacketWriter WriterFactory()
+        {
+            return new SpanBasedMqttPacketWriter();
+        }
     }
 }

--- a/Tests/MQTTnet.AspNetCore.Tests/MqttPacketSerializerTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/MqttPacketSerializerTests.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MQTTnet.Core.Tests;
-using MQTTnet.Serializer;
+using MQTTnet.Formatter;
+using MQTTnet.Tests;
 
 namespace MQTTnet.AspNetCore.Tests
 {
     [TestClass]
-    public class MqttPacketSerializerTestsWithSpanBasedReader : MqttPacketSerializerTests
+    public class MqttPacketSerializerTestsWithSpanBasedReader : MqttPacketSerializer_Tests
     {
-        protected override IPacketBodyReader ReaderFactory(byte[] data)
+        protected override IMqttPacketBodyReader ReaderFactory(byte[] data)
         {
             var result = new SpanBasedMqttPacketBodyReader();
             result.SetBuffer(data);

--- a/Tests/MQTTnet.AspNetCore.Tests/MqttPacketSerializerTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/MqttPacketSerializerTests.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Core.Tests;
+using MQTTnet.Serializer;
+
+namespace MQTTnet.AspNetCore.Tests
+{
+    [TestClass]
+    public class MqttPacketSerializerTestsWithSpanBasedReader : MqttPacketSerializerTests
+    {
+        protected override IPacketBodyReader ReaderFactory(byte[] data)
+        {
+            var result = new SpanBasedMqttPacketBodyReader();
+            result.SetBuffer(data);
+            return result;
+        }
+    }
+}

--- a/Tests/MQTTnet.AspNetCore.Tests/ReaderExtensionsTest.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/ReaderExtensionsTest.cs
@@ -24,21 +24,23 @@ namespace MQTTnet.AspNetCore.Tests
             var observed = part.Start;
             var result = false;
 
+            var reader = new SpanBasedMqttPacketBodyReader();
+
             part = sequence.Slice(sequence.Start, 0); // empty message should fail
-            result = serializer.TryDecode(part, out packet, out consumed, out observed);
+            result = serializer.TryDecode(reader, part, out packet, out consumed, out observed);
             Assert.IsFalse(result);
 
 
             part = sequence.Slice(sequence.Start, 1); // partial fixed header should fail
-            result = serializer.TryDecode(part, out packet, out consumed, out observed);
+            result = serializer.TryDecode(reader, part, out packet, out consumed, out observed);
             Assert.IsFalse(result);
 
             part = sequence.Slice(sequence.Start, 4); // partial body should fail
-            result = serializer.TryDecode(part, out packet, out consumed, out observed);
+            result = serializer.TryDecode(reader, part, out packet, out consumed, out observed);
             Assert.IsFalse(result);
 
             part = sequence; // complete msg should work
-            result = serializer.TryDecode(part, out packet, out consumed, out observed);
+            result = serializer.TryDecode(reader, part, out packet, out consumed, out observed);
             Assert.IsTrue(result);
         }
     }

--- a/Tests/MQTTnet.Benchmarks/Configurations/AllowNonOptimized.cs
+++ b/Tests/MQTTnet.Benchmarks/Configurations/AllowNonOptimized.cs
@@ -3,20 +3,17 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Validators;
 
-namespace MQTTnet.Benchmarks
+namespace MQTTnet.Benchmarks.Configurations
 {
     /// <summary>
     /// this options may be used to run benchmarks in debugmode and attach a performance profiler
     /// https://benchmarkdotnet.org/Configs/Configs.htm
     /// </summary>
-    public class AllowNonOptimized : ManualConfig
+    public class AllowNonOptimized : BaseConfig
     {
         public AllowNonOptimized()
         {
             Add(JitOptimizationsValidator.DontFailOnError); // ALLOW NON-OPTIMIZED DLLS
-            Add(DefaultConfig.Instance.GetLoggers().ToArray()); // manual config has no loggers by default
-            Add(DefaultConfig.Instance.GetExporters().ToArray()); // manual config has no exporters by default
-            Add(DefaultConfig.Instance.GetColumnProviders().ToArray()); // manual config has no columns by default
             Add(Job.InProcess);
         }
     }

--- a/Tests/MQTTnet.Benchmarks/Configurations/BaseConfig.cs
+++ b/Tests/MQTTnet.Benchmarks/Configurations/BaseConfig.cs
@@ -1,0 +1,15 @@
+﻿using BenchmarkDotNet.Configs;
+using System.Linq;
+
+namespace MQTTnet.Benchmarks.Configurations
+{
+    public class BaseConfig : ManualConfig
+    {
+        public BaseConfig()
+        {
+            Add(DefaultConfig.Instance.GetLoggers().ToArray()); // manual config has no loggers by default
+            Add(DefaultConfig.Instance.GetExporters().ToArray()); // manual config has no exporters by default
+            Add(DefaultConfig.Instance.GetColumnProviders().ToArray()); // manual config has no columns by default
+        }
+    }
+}

--- a/Tests/MQTTnet.Benchmarks/Configurations/RuntimeCompareConfig.cs
+++ b/Tests/MQTTnet.Benchmarks/Configurations/RuntimeCompareConfig.cs
@@ -1,0 +1,17 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
+
+namespace MQTTnet.Benchmarks.Configurations
+{
+    public class RuntimeCompareConfig : BaseConfig
+    {
+        public RuntimeCompareConfig()
+        {
+            Add(Job.Default.With(Runtime.Clr));
+            Add(Job.Default.With(Runtime.Core).With(CsProjCoreToolchain.NetCoreApp21));
+        }
+
+    }
+}

--- a/Tests/MQTTnet.Benchmarks/MQTTnet.Benchmarks.csproj
+++ b/Tests/MQTTnet.Benchmarks/MQTTnet.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <DebugType>Full</DebugType>
-    <TargetFramework Condition=" '$(OS)' == 'Windows_NT' ">net461</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net461;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>

--- a/Tests/MQTTnet.Benchmarks/Program.cs
+++ b/Tests/MQTTnet.Benchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BenchmarkDotNet.Running;
+using MQTTnet.Benchmarks.Configurations;
 using MQTTnet.Diagnostics;
 
 namespace MQTTnet.Benchmarks
@@ -43,7 +44,7 @@ namespace MQTTnet.Benchmarks
                     BenchmarkRunner.Run<TcpPipesBenchmark>();
                     break;
                 case '8':
-                    BenchmarkRunner.Run<MessageProcessingMqttConnectionContextBenchmark>(new AllowNonOptimized());
+                    BenchmarkRunner.Run<MessageProcessingMqttConnectionContextBenchmark>(new RuntimeCompareConfig()/*new AllowNonOptimized()*/);
                     break;
             }
 

--- a/Tests/MQTTnet.Core.Tests/MqttPacketSerializer_Tests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttPacketSerializer_Tests.cs
@@ -528,7 +528,12 @@ namespace MQTTnet.Tests
             Assert.AreEqual(expectedBase64Value, Convert.ToBase64String(Join(data)));
         }
 
-        private static void DeserializeAndCompare(MqttBasePacket packet, string expectedBase64Value, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
+        protected virtual IMqttPacketBodyReader ReaderFactory(byte[] data)
+        {
+            return new MqttPacketBodyReader(data, 0, data.Length);
+        }
+
+        private void DeserializeAndCompare(MqttBasePacket packet, string expectedBase64Value, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
         {
             IMqttPacketFormatter serializer;
             if (protocolVersion == MqttProtocolVersion.V311)

--- a/Tests/MQTTnet.Core.Tests/MqttPacketSerializer_Tests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttPacketSerializer_Tests.cs
@@ -528,6 +528,11 @@ namespace MQTTnet.Tests
             Assert.AreEqual(expectedBase64Value, Convert.ToBase64String(Join(data)));
         }
 
+        protected virtual IMqttPacketWriter WriterFactory()
+        {
+            return new MqttPacketWriter();
+        }
+
         protected virtual IMqttPacketBodyReader ReaderFactory(byte[] data)
         {
             return new MqttPacketBodyReader(data, 0, data.Length);
@@ -535,14 +540,16 @@ namespace MQTTnet.Tests
 
         private void DeserializeAndCompare(MqttBasePacket packet, string expectedBase64Value, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
         {
+            var writer = WriterFactory();
+
             IMqttPacketFormatter serializer;
             if (protocolVersion == MqttProtocolVersion.V311)
             {
-                serializer = new MqttV311PacketFormatter();
+                serializer = new MqttV311PacketFormatter(writer);
             }
             else if (protocolVersion == MqttProtocolVersion.V310)
             {
-                serializer = new MqttV310PacketFormatter();
+                serializer = new MqttV310PacketFormatter(writer);
             }
             else
             {
@@ -559,7 +566,8 @@ namespace MQTTnet.Tests
 
                 using (var bodyStream = new MemoryStream(Join(buffer1), (int)headerStream.Position, header.RemainingLength))
                 {
-                    var deserializedPacket = serializer.Decode(new ReceivedMqttPacket(header.Flags, new MqttPacketBodyReader(bodyStream.ToArray(), 0, (int)bodyStream.Length), 0));
+                    var reader = ReaderFactory(bodyStream.ToArray());
+                    var deserializedPacket = serializer.Decode(new ReceivedMqttPacket(header.Flags, reader, 0));
                     var buffer2 = serializer.Encode(deserializedPacket);
 
                     Assert.AreEqual(expectedBase64Value, Convert.ToBase64String(Join(buffer2)));
@@ -567,17 +575,19 @@ namespace MQTTnet.Tests
             }
         }
 
-        private static T Roundtrip<T>(T packet, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
+        private T Roundtrip<T>(T packet, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311)
             where T : MqttBasePacket
         {
+            var writer = WriterFactory();
+
             IMqttPacketFormatter serializer;
             if (protocolVersion == MqttProtocolVersion.V311)
             {
-                serializer = new MqttV311PacketFormatter();
+                serializer = new MqttV311PacketFormatter(writer);
             }
             else if (protocolVersion == MqttProtocolVersion.V310)
             {
-                serializer = new MqttV310PacketFormatter();
+                serializer = new MqttV310PacketFormatter(writer);
             }
             else
             {
@@ -595,7 +605,8 @@ namespace MQTTnet.Tests
 
                 using (var bodyStream = new MemoryStream(Join(buffer1), (int)headerStream.Position, (int)header.RemainingLength))
                 {
-                    return (T)serializer.Decode(new ReceivedMqttPacket(header.Flags, new MqttPacketBodyReader(bodyStream.ToArray(), 0, (int)bodyStream.Length), 0));
+                    var reader = ReaderFactory(bodyStream.ToArray());
+                    return (T)serializer.Decode(new ReceivedMqttPacket(header.Flags, reader, 0));
                 }
             }
         }


### PR DESCRIPTION
I cannot compare with before because the current dev branch is not able to run the benchmark.

see commit "fixed another issue", seems the mqtt v5 changes introduced an issue in the aspnet part of the codebase.


this is what it looks like after my changes:

|              Method | Runtime |     Toolchain |     Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|-------------------- |-------- |-------------- |---------:|----------:|----------:|----------:|---------:|--------:|----------:|
| Send_10000_Messages |     Clr |       Default | 25.30 ms | 0.4913 ms | 0.6213 ms | 2562.5000 |  93.7500 | 31.2500 |   10.7 MB |
| Send_10000_Messages |    Core | .NET Core 2.1 | 12.19 ms | 0.3646 ms | 1.0225 ms | 1718.7500 | 546.8750 | 31.2500 |   1.45 MB |

vs 2019 includes an improved profiler it seems with it I can spot many more allocations per message I would like to get rid of. most of them require changes of apis so I left them like they are and just focused on reducing the number of byte[] allocations.

ValueTask instead of Task was one option I saw benifit in my first attempt but to keep the scope of the change smaller I left that like it is. 

![image](https://user-images.githubusercontent.com/6747376/56138361-0def5580-5f97-11e9-8d41-5468b24d8847.png)

@chkr1011 pls do a review asap. I dont want the branch to get stale again. 

