### PR TITLE
Add remote certificate validation callback on server

### DIFF
--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -160,7 +160,7 @@ namespace MQTTnet.Implementations
 
                 if (_tlsCertificate != null)
                 {
-                    var sslStream = new SslStream(stream, false);
+                    var sslStream = new SslStream(stream, false, _tlsOptions.RemoteCertificateValidationCallback);
 
                     await sslStream.AuthenticateAsServerAsync(
                         _tlsCertificate, 

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Authentication;
+﻿using System.Net.Security;
+using System.Security.Authentication;
 
 namespace MQTTnet.Server
 {
@@ -14,7 +15,9 @@ namespace MQTTnet.Server
         public bool ClientCertificateRequired { get; set; }
 
         public bool CheckCertificateRevocation { get; set; }
-        
+
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
     }
 }


### PR DESCRIPTION
Add remote certificate validation callback on server.
It is possible to validate the CA certificate without having to install it on the machine.