### PR TITLE
Fixed AsyncLock::WaitAsync cancellation bug

### DIFF
--- a/Source/MQTTnet/Internal/AsyncLock.cs
+++ b/Source/MQTTnet/Internal/AsyncLock.cs
@@ -23,7 +23,7 @@ namespace MQTTnet.Internal
         public Task<IDisposable> WaitAsync(CancellationToken cancellationToken)
         {
             var task = _semaphore.WaitAsync(cancellationToken);
-            if (task.IsCompleted)
+            if (task.Status == TaskStatus.RanToCompletion)
             {
                 return _releaser;
             }


### PR DESCRIPTION
There isn't any code in MQTTnet that actually uses a cancellation token in WaitAsync, so this is more of a preventative thing than a bug fix.  The original code just checks if the task was completed, not whether it was cancelled.  If the process is cancelled immediately before the call to WaitAsync, it'll return as normal (https://referencesource.microsoft.com/#mscorlib/system/threading/SemaphoreSlim.cs,612) rather than throw a cancellation exception.  This change will ensure we only return the releaser if the wait actually ran to completion rather than exited early due to cancellation.  I've tested this, and it properly throws a cancellation exception later on.  (Credit for this fix goes to my co-worker @mwinterb)