### PR TITLE
Add Server certificate password and client certificate builders

### DIFF
--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -139,6 +139,13 @@ namespace MQTTnet.Client.Options
             return this;
         }
 
+        public MqttClientOptionsBuilder WithCredentials(IMqttClientCredentials credentials)
+        {
+            _options.Credentials = credentials;
+
+            return this;
+        }
+
         public MqttClientOptionsBuilder WithExtendedAuthenticationExchangeHandler(IMqttExtendedAuthenticationExchangeHandler handler)
         {
             _options.ExtendedAuthenticationExchangeHandler = handler;

--- a/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
@@ -48,7 +48,7 @@ namespace MQTTnet.Implementations
                     throw new ArgumentException("TLS certificate is not set.");
                 }
 
-                var tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate);
+                var tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate, options.TlsEndpointOptions.Password.Password);
                 if (!tlsCertificate.HasPrivateKey)
                 {
                     throw new InvalidOperationException("The certificate for TLS encryption must contain the private key.");

--- a/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
@@ -48,7 +48,7 @@ namespace MQTTnet.Implementations
                     throw new ArgumentException("TLS certificate is not set.");
                 }
 
-                var tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate, options.TlsEndpointOptions.Password.Password);
+                var tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate, options.TlsEndpointOptions.CertificateCredentials.Password);
                 if (!tlsCertificate.HasPrivateKey)
                 {
                     throw new InvalidOperationException("The certificate for TLS encryption must contain the private key.");

--- a/Source/MQTTnet/Server/IMqttServerCredentials.cs
+++ b/Source/MQTTnet/Server/IMqttServerCredentials.cs
@@ -1,0 +1,6 @@
+using System;
+
+public interface IMqttServerCredentials
+{
+    String Password { get; }
+}

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -82,15 +82,24 @@ namespace MQTTnet.Server
             return this;
         }
 
-        public MqttServerOptionsBuilder WithEncryptionCertificate(byte[] value)
+        public MqttServerOptionsBuilder WithEncryptionCertificate(byte[] value, IMqttServerCredentials password = null)
         {
             _options.TlsEndpointOptions.Certificate = value;
+            _options.TlsEndpointOptions.Password = password;
             return this;
         }
 
         public MqttServerOptionsBuilder WithEncryptionSslProtocol(SslProtocols value)
         {
             _options.TlsEndpointOptions.SslProtocol = value;
+            return this;
+        }
+
+        public MqttServerOptionsBuilder WithClientCertificate(RemoteCertificateValidationCallback validationCallback = null, bool checkCertificateRevocation = false)
+        {
+            _options.TlsEndpointOptions.ClientCertificateRequired = true;
+            _options.TlsEndpointOptions.CheckCertificateRevocation = checkCertificateRevocation;
+            _options.TlsEndpointOptions.CertificateValidationCallback = validationCallback;
             return this;
         }
 
@@ -107,7 +116,7 @@ namespace MQTTnet.Server
             return this;
         }
 #endif
-
+        
         public MqttServerOptionsBuilder WithStorage(IMqttServerStorage value)
         {
             _options.Storage = value;

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -95,13 +95,15 @@ namespace MQTTnet.Server
             return this;
         }
 
+#if !WINDOWS_UWP
         public MqttServerOptionsBuilder WithClientCertificate(RemoteCertificateValidationCallback validationCallback = null, bool checkCertificateRevocation = false)
         {
             _options.TlsEndpointOptions.ClientCertificateRequired = true;
             _options.TlsEndpointOptions.CheckCertificateRevocation = checkCertificateRevocation;
-            _options.TlsEndpointOptions.CertificateValidationCallback = validationCallback;
+            _options.TlsEndpointOptions.RemoteCertificateValidationCallback = validationCallback;
             return this;
         }
+#endif
 
         public MqttServerOptionsBuilder WithoutEncryptedEndpoint()
         {

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -82,10 +82,10 @@ namespace MQTTnet.Server
             return this;
         }
 
-        public MqttServerOptionsBuilder WithEncryptionCertificate(byte[] value, IMqttServerCredentials password = null)
+        public MqttServerOptionsBuilder WithEncryptionCertificate(byte[] value, IMqttServerCredentials credentials = null)
         {
             _options.TlsEndpointOptions.Certificate = value;
-            _options.TlsEndpointOptions.Password = password;
+            _options.TlsEndpointOptions.CertificateCredentials = credentials;
             return this;
         }
 

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -12,6 +12,8 @@ namespace MQTTnet.Server
 
         public byte[] Certificate { get; set; }
 
+        public IMqttServerCredentials Password { get; set; }
+
         public bool ClientCertificateRequired { get; set; }
 
         public bool CheckCertificateRevocation { get; set; }

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -12,7 +12,7 @@ namespace MQTTnet.Server
 
         public byte[] Certificate { get; set; }
 
-        public IMqttServerCredentials Password { get; set; }
+        public IMqttServerCredentials CertificateCredentials { get; set; }
 
         public bool ClientCertificateRequired { get; set; }
 


### PR DESCRIPTION
Exposed interfaces in builder pattern to provide support to configure an optional password to be used when loading a server certificate from a file that is password protected.

Added support to enable Client Certificate exchange via builder pattern.