### PR TITLE
Fix Client SslStream CRL verification

### DIFF
--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -252,6 +252,7 @@ namespace MQTTnet.Extensions.ManagedClient
                 _maintainConnectionTask = null;
             }
 
+            _messageQueueLock.Dispose();
             _mqttClient.Dispose();
         }
 

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -86,7 +86,7 @@ namespace MQTTnet.Implementations
                 var sslStream = new SslStream(networkStream, false, InternalUserCertificateValidationCallback);
                 _stream = sslStream;
 
-                await sslStream.AuthenticateAsClientAsync(_options.Server, LoadCertificates(), _options.TlsOptions.SslProtocol, _options.TlsOptions.IgnoreCertificateRevocationErrors).ConfigureAwait(false);                
+                await sslStream.AuthenticateAsClientAsync(_options.Server, LoadCertificates(), _options.TlsOptions.SslProtocol, !_options.TlsOptions.IgnoreCertificateRevocationErrors).ConfigureAwait(false);                
             }
             else
             {


### PR DESCRIPTION
Logic appears to be inverted. When IgnoreCertificateRevocationErrors, SslStream was requested to checkCertificateRevocation which were then ignored in the callout validator.

Also, it looks like a managed object dispose was missed, a little cleanup.