### PR TITLE
Better handling of AssignedClientIdentifier - chkr1011/MQTTnet#745

### DIFF
--- a/Source/MQTTnet/Server/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/MqttClientSessionsManager.cs
@@ -240,9 +240,9 @@ namespace MQTTnet.Server
                     return;
                 }
 
-                clientId = connectPacket.ClientId;
-
                 var connectionValidatorContext = await ValidateConnectionAsync(connectPacket, channelAdapter).ConfigureAwait(false);
+
+                clientId = connectPacket.ClientId;
 
                 if (connectionValidatorContext.ReasonCode != MqttConnectReasonCode.Success)
                 {
@@ -258,7 +258,7 @@ namespace MQTTnet.Server
 
                 await _eventDispatcher.HandleClientConnectedAsync(clientId).ConfigureAwait(false);
                 
-                disconnectType = await connection.RunAsync().ConfigureAwait(false);
+                disconnectType = await connection.RunAsync(connectionValidatorContext).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
Allow AssignedClientIdentifier in ClientConnected, ClientDisconnected and ConnectedHandler.
Fixes chkr1011/MQTTnet#745
