### PR TITLE
Remove if clause that stopped handling of tasks with exceptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve.
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -2,7 +2,7 @@
 name: Custom issue template
 about: Do you have a question related to the project? Use this template.
 title: ''
-labels: ''
+labels: 'question'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project.
 title: ''
-labels: ''
+labels: 'feature-request'
 assignees: ''
 
 ---

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -646,7 +646,7 @@ namespace MQTTnet.Client
 
                 // By accessing the Exception property the exception is considered handled and will
                 // not result in an unhandled task exception later by the finalizer
-                _logger.Warning(task.Exception, "Exception when waiting for background task.");
+                _logger.Warning(task.Exception, "Error while waiting for background task.");
                 return;
             }
 

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -149,7 +149,7 @@ namespace MQTTnet.Client
                 Properties = new MqttAuthPacketProperties
                 {
                     // This must always be equal to the value from the CONNECT packet. So we use it here to ensure that.
-                    AuthenticationMethod = Options.AuthenticationMethod, 
+                    AuthenticationMethod = Options.AuthenticationMethod,
                     AuthenticationData = data.AuthenticationData,
                     ReasonString = data.ReasonString,
                     UserProperties = data.UserProperties
@@ -567,7 +567,7 @@ namespace MQTTnet.Client
                         };
 
                         await SendAsync(pubRecPacket, cancellationToken).ConfigureAwait(false);
-                    }                    
+                    }
                 }
                 else
                 {
@@ -629,11 +629,6 @@ namespace MQTTnet.Client
         private static async Task WaitForTaskAsync(Task task, Task sender)
         {
             if (task == sender || task == null)
-            {
-                return;
-            }
-
-            if (task.IsCanceled || task.IsCompleted || task.IsFaulted)
             {
                 return;
             }

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -269,8 +269,10 @@ namespace MQTTnet.Client
                     await _adapter.DisconnectAsync(Options.CommunicationTimeout, CancellationToken.None).ConfigureAwait(false);
                 }
 
-                await WaitForTaskAsync(_packetReceiverTask, sender).ConfigureAwait(false);
-                await WaitForTaskAsync(_keepAlivePacketsSenderTask, sender).ConfigureAwait(false);
+                var receiverTask =  WaitForTaskAsync(_packetReceiverTask, sender);
+                var keepAliveTask = WaitForTaskAsync(_keepAlivePacketsSenderTask, sender);
+                
+                await Task.WhenAll(receiverTask, keepAliveTask).ConfigureAwait(false);
 
                 _logger.Verbose("Disconnected from adapter.");
             }


### PR DESCRIPTION
If any of the tasks that are awaited with the method `WaitForTaskAsync` throws an exception this would result in an `UnhandledTaskException` and crashing the application. With the changes made here the tasks will always be awaited and thus also the exception will be handled.

Solves the unhandled task exception part of issue #158