### PR TITLE
Reduce subscription publishing loglevel in ManagedMqttClient

### DIFF
--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -475,7 +475,7 @@ namespace MQTTnet.Extensions.ManagedClient
                     continue;
                 }
 
-                _logger.Info("Publishing subscriptions");
+                _logger.Verbose($"Publishing subscriptions ({subscriptions.Count} subscriptions and {unsubscriptions.Count} unsubscriptions)");
 
                 foreach (var unsubscription in unsubscriptions)
                 {


### PR DESCRIPTION
 - the Info level for publishing subscriptions is quite noisy
 - previously this wasn't a problem because subscription processing was buffered, now the message is logged for nearly every single un/subscription that is made
 - all other frequently recurring log events are also on level Verbose
 - include some additional info when a log entry is made