### PR TITLE
Add an x509 certificate parameter

### DIFF
--- a/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
@@ -43,13 +43,17 @@ namespace MQTTnet.Implementations
 
             if (options.TlsEndpointOptions?.IsEnabled == true)
             {
-                if (options.TlsEndpointOptions.Certificate == null)
+                if (options.TlsEndpointOptions.Certificate == null && options.TlsEndpointOptions.X509Certificate == null)
                 {
                     throw new ArgumentException("TLS certificate is not set.");
                 }
 
                 X509Certificate2 tlsCertificate;
-                if (string.IsNullOrEmpty(options.TlsEndpointOptions.CertificateCredentials?.Password))
+                if (options.TlsEndpointOptions.X509Certificate != null)
+                {
+                    tlsCertificate = options.TlsEndpointOptions.X509Certificate;
+                }
+                else if (string.IsNullOrEmpty(options.TlsEndpointOptions.CertificateCredentials?.Password))
                 {
                     // Use a different overload when no password is specified. Otherwise the constructor will fail.
                     tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate);
@@ -58,7 +62,7 @@ namespace MQTTnet.Implementations
                 {
                     tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate, options.TlsEndpointOptions.CertificateCredentials.Password);
                 }
-                
+
                 if (!tlsCertificate.HasPrivateKey)
                 {
                     throw new InvalidOperationException("The certificate for TLS encryption must contain the private key.");

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Server
 {
@@ -57,7 +58,7 @@ namespace MQTTnet.Server
             _options.DefaultEndpointOptions.IsEnabled = false;
             return this;
         }
-        
+
         public MqttServerOptionsBuilder WithEncryptedEndpoint()
         {
             _options.TlsEndpointOptions.IsEnabled = true;
@@ -86,6 +87,12 @@ namespace MQTTnet.Server
         {
             _options.TlsEndpointOptions.Certificate = value;
             _options.TlsEndpointOptions.CertificateCredentials = credentials;
+            return this;
+        }
+
+        public MqttServerOptionsBuilder WithEncryptionCertificate(X509Certificate2 certificate)
+        {
+            _options.TlsEndpointOptions.X509Certificate = certificate;
             return this;
         }
 
@@ -118,7 +125,7 @@ namespace MQTTnet.Server
             return this;
         }
 #endif
-        
+
         public MqttServerOptionsBuilder WithStorage(IMqttServerStorage value)
         {
             _options.Storage = value;

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -90,11 +90,13 @@ namespace MQTTnet.Server
             return this;
         }
 
+#if !WINDOWS_UWP
         public MqttServerOptionsBuilder WithEncryptionCertificate(X509Certificate2 certificate)
         {
             _options.TlsEndpointOptions.X509Certificate = certificate;
             return this;
         }
+#endif
 
         public MqttServerOptionsBuilder WithEncryptionSslProtocol(SslProtocols value)
         {

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -13,7 +13,9 @@ namespace MQTTnet.Server
 
         public byte[] Certificate { get; set; }
 
+#if !WINDOWS_UWP
         public X509Certificate2 X509Certificate { get; set; }
+#endif
 
         public IMqttServerCertificateCredentials CertificateCredentials { get; set; }
 

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Server
 {
@@ -11,6 +12,8 @@ namespace MQTTnet.Server
         }
 
         public byte[] Certificate { get; set; }
+
+        public X509Certificate2 X509Certificate { get; set; }
 
         public IMqttServerCertificateCredentials CertificateCredentials { get; set; }
 


### PR DESCRIPTION
Closes #796 

Adds a way to set the server's certificate using an `X509Certificate2` directly instead of needing to export it to `byte[]`.