### PR TITLE
Replace raw bytes with x509 certificate to allow specify passwords and flags

### DIFF
--- a/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttChannel.cs
+++ b/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttChannel.cs
@@ -85,7 +85,7 @@ namespace MQTTnet.Extensions.WebSocket4Net
             {
                 foreach (var certificate in _webSocketOptions.TlsOptions.Certificates)
                 {
-                    certificates.Add(new X509Certificate(certificate));
+                    certificates.Add(certificate);
                 }
             }
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -256,7 +256,7 @@ namespace MQTTnet.Client.Options
                         UseTls = true,
                         SslProtocol = _tlsParameters.SslProtocol,
                         AllowUntrustedCertificates = _tlsParameters.AllowUntrustedCertificates,
-                        Certificates = _tlsParameters.Certificates?.Select(c => c.ToArray()).ToList(),
+                        Certificates = _tlsParameters.Certificates?.ToList(),
                         CertificateValidationCallback = _tlsParameters.CertificateValidationCallback,
                         IgnoreCertificateChainErrors = _tlsParameters.IgnoreCertificateChainErrors,
                         IgnoreCertificateRevocationErrors = _tlsParameters.IgnoreCertificateRevocationErrors

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
@@ -18,7 +18,7 @@ namespace MQTTnet.Client.Options
 
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
 
-        public IEnumerable<IEnumerable<byte>> Certificates { get; set; }
+        public IEnumerable<X509Certificate> Certificates { get; set; }
 
         public bool AllowUntrustedCertificates { get; set; }
 

--- a/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
@@ -16,7 +16,7 @@ namespace MQTTnet.Client.Options
 
         public bool AllowUntrustedCertificates { get; set; }
 
-        public List<byte[]> Certificates { get; set; }
+        public List<X509Certificate> Certificates { get; set; }
 
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
 

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.Uwp.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.Uwp.cs
@@ -132,7 +132,7 @@ namespace MQTTnet.Implementations
                 throw new NotSupportedException("Only one client certificate is supported for UWP.");
             }
 
-            return new Certificate(options.TlsOptions.Certificates.First().AsBuffer());
+            return new Certificate(options.TlsOptions.Certificates.First().GetRawCertData());
         }
 
         private IEnumerable<ChainValidationResult> ResolveIgnorableServerCertificateErrors()

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -214,7 +214,7 @@ namespace MQTTnet.Implementations
 
             foreach (var certificate in _options.TlsOptions.Certificates)
             {
-                certificates.Add(new X509Certificate2(certificate));
+                certificates.Add(certificate);
             }
 
             return certificates;

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -84,7 +84,7 @@ namespace MQTTnet.Implementations
                 clientWebSocket.Options.ClientCertificates = new X509CertificateCollection();
                 foreach (var certificate in _options.TlsOptions.Certificates)
                 {
-                    clientWebSocket.Options.ClientCertificates.Add(new X509Certificate(certificate));
+                    clientWebSocket.Options.ClientCertificates.Add(certificate);
                 }
             }
 


### PR DESCRIPTION
Currently, there is no way to specify `Password` and `StorageFlags` for certificates used by MQTT client. This PR should extend certificates support.

Not tested with UWP