### PR TITLE
Replace raw bytes with x509 certificate to allow specify passwords and flags #2

### DIFF
--- a/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttChannel.cs
+++ b/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttChannel.cs
@@ -85,7 +85,12 @@ namespace MQTTnet.Extensions.WebSocket4Net
             {
                 foreach (var certificate in _webSocketOptions.TlsOptions.Certificates)
                 {
+#if WINDOWS_UWP
                     certificates.Add(new X509Certificate(certificate));
+#else
+                    certificates.Add(certificate);
+#endif
+                    
                 }
             }
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -256,7 +256,11 @@ namespace MQTTnet.Client.Options
                         UseTls = true,
                         SslProtocol = _tlsParameters.SslProtocol,
                         AllowUntrustedCertificates = _tlsParameters.AllowUntrustedCertificates,
+#if WINDOWS_UWP
                         Certificates = _tlsParameters.Certificates?.Select(c => c.ToArray()).ToList(),
+#else
+                        Certificates = _tlsParameters.Certificates?.ToList(),
+#endif
                         CertificateValidationCallback = _tlsParameters.CertificateValidationCallback,
                         IgnoreCertificateChainErrors = _tlsParameters.IgnoreCertificateChainErrors,
                         IgnoreCertificateRevocationErrors = _tlsParameters.IgnoreCertificateRevocationErrors

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
@@ -18,7 +18,12 @@ namespace MQTTnet.Client.Options
 
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
 
+#if WINDOWS_UWP
         public IEnumerable<IEnumerable<byte>> Certificates { get; set; }
+#else
+        public IEnumerable<X509Certificate> Certificates { get; set; }
+#endif
+        
 
         public bool AllowUntrustedCertificates { get; set; }
 

--- a/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
@@ -15,8 +15,11 @@ namespace MQTTnet.Client.Options
         public bool IgnoreCertificateChainErrors { get; set; }
 
         public bool AllowUntrustedCertificates { get; set; }
-
+#if WINDOWS_UWP
         public List<byte[]> Certificates { get; set; }
+#else
+        public List<X509Certificate> Certificates { get; set; }
+#endif
 
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
 

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -214,7 +214,7 @@ namespace MQTTnet.Implementations
 
             foreach (var certificate in _options.TlsOptions.Certificates)
             {
-                certificates.Add(new X509Certificate2(certificate));
+                certificates.Add(certificate);
             }
 
             return certificates;

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -84,7 +84,12 @@ namespace MQTTnet.Implementations
                 clientWebSocket.Options.ClientCertificates = new X509CertificateCollection();
                 foreach (var certificate in _options.TlsOptions.Certificates)
                 {
+#if WINDOWS_UWP
                     clientWebSocket.Options.ClientCertificates.Add(new X509Certificate(certificate));
+#else
+                    clientWebSocket.Options.ClientCertificates.Add(certificate);
+#endif
+                    
                 }
             }
 


### PR DESCRIPTION
Currently, there is no way to specify Password and StorageFlags for certificates used by MQTT client. This PR should extend certificates support.

Not tested with UWP

Added UWP compiler flags, so for now - for UWP it behaves in the same way as before