### PR TITLE
Added IMqttExtendedServerStorage

### DIFF
--- a/Source/MQTTnet/Server/IMqttServerOptions.cs
+++ b/Source/MQTTnet/Server/IMqttServerOptions.cs
@@ -21,8 +21,6 @@ namespace MQTTnet.Server
         MqttServerTcpEndpointOptions DefaultEndpointOptions { get; }
         MqttServerTlsTcpEndpointOptions TlsEndpointOptions { get; }
 
-        IMqttServerStorage Storage { get; }       
-        
-
+        IMqttServerStorage Storage { get; }
     }
 }

--- a/Source/MQTTnet/Server/IMqttServerStorage.cs
+++ b/Source/MQTTnet/Server/IMqttServerStorage.cs
@@ -9,4 +9,15 @@ namespace MQTTnet.Server
 
         Task<IList<MqttApplicationMessage>> LoadRetainedMessagesAsync();
     }
+
+    public interface IMqttExtendedServerStorage : IMqttServerStorage
+    {
+        Task<bool> HandleMessageAsync(string clientId, MqttApplicationMessage applicationMessage);
+
+        Task<IList<MqttApplicationMessage>> GetMessagesAsync();
+
+        Task<List<MqttApplicationMessage>> GetSubscribedMessagesAsync(ICollection<TopicFilter> topicFilters);
+
+        Task ClearMessagesAsync();
+    }
 }


### PR DESCRIPTION
The current IMqttServerStorage interface is sub-optimal
for large installations with thounsands of retained messages:
each single new retained messages enforces a call to
`SaveRetainedMessagesAsync` with the full list of all
messages.

The new interface allows for complete delegation of how to
store retained messages to client code.