### PR TITLE
Add .NET 3.1 target

### DIFF
--- a/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
+++ b/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <Product />
     <Company />
     <Authors />
@@ -14,7 +14,11 @@
     <DefineConstants>RELEASE;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+    
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />


### PR DESCRIPTION
Add .NET Core 3.1 target to `MQTTnet.AspNetCore` that uses ASP.NET Core framework reference instead of NuGet package references