### PR TITLE
fix IMqttChannelAdapter.Endpoint Property in asp.net core

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -25,7 +25,7 @@ namespace MQTTnet.AspNetCore
                 _input = Connection.Transport.Input;
                 _output = Connection.Transport.Output;
             }
-            
+
             _reader = new SpanBasedMqttPacketBodyReader();
         }
 
@@ -38,12 +38,7 @@ namespace MQTTnet.AspNetCore
             get
             {
                 var connection = Http?.HttpContext?.Connection;
-                if (connection == null)
-                {
-                    return Connection.ConnectionId;
-                }
-
-                return $"{connection.RemoteIpAddress}:{connection.RemotePort}";
+                return connection == null ? Connection.ConnectionId : $"{connection.RemoteIpAddress}:{connection.RemotePort}";
             }
         }
 


### PR DESCRIPTION
Use the HttpContext. Connection. RemoteEndpoint instead of ConnectionContext. Id in asp.net core.