### PR TITLE
Use IConnectionEndPointFeature to get IMqttChannelAdapter.Endpoint in aspnetcore31

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -38,10 +38,9 @@ namespace MQTTnet.AspNetCore
             get
             {
 #if NETCOREAPP3_1
-                var endpointFeature = Connection.Features.Get<Microsoft.AspNetCore.Connections.Features.IConnectionEndPointFeature>();
-                if (endpointFeature != null)
+                if (Connection?.RemoteEndPoint != null)
                 {
-                    return endpointFeature.RemoteEndPoint.ToString();
+                    return Connection.RemoteEndPoint.ToString();
                 }
 #endif
                 var connection = Http?.HttpContext?.Connection;

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -25,7 +25,7 @@ namespace MQTTnet.AspNetCore
                 _input = Connection.Transport.Input;
                 _output = Connection.Transport.Output;
             }
-            
+
             _reader = new SpanBasedMqttPacketBodyReader();
         }
 
@@ -37,6 +37,13 @@ namespace MQTTnet.AspNetCore
         {
             get
             {
+#if NETCOREAPP3_1
+                var endpointFeature = Connection.Features.Get<Microsoft.AspNetCore.Connections.Features.IConnectionEndPointFeature>();
+                if (endpointFeature != null)
+                {
+                    return endpointFeature.RemoteEndPoint.ToString();
+                }
+#endif
                 var connection = Http?.HttpContext?.Connection;
                 if (connection == null)
                 {

--- a/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
+++ b/Tests/MQTTnet.AspNetCore.Tests/MQTTnet.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -11,6 +11,12 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\Source\MQTTnet.AspnetCore\MQTTnet.AspNetCore.csproj" />
     <ProjectReference Include="..\MQTTnet.Core.Tests\MQTTnet.Tests.csproj" />

--- a/Tests/MQTTnet.AspNetCore.Tests/Mockups/ConnectionHandlerMockup.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/Mockups/ConnectionHandlerMockup.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Connections;
+using MQTTnet.Adapter;
+using MQTTnet.Formatter;
+using MQTTnet.Server;
+using System;
+using System.Threading.Tasks;
+
+namespace MQTTnet.AspNetCore.Tests.Mockups
+{
+    public class ConnectionHandlerMockup: IMqttServerAdapter
+    {
+        public TaskCompletionSource<MqttConnectionContext> Context { get; } = new TaskCompletionSource<MqttConnectionContext>();
+        public Func<IMqttChannelAdapter, Task> ClientHandler { get; set; }
+
+        public ConnectionHandlerMockup()
+        {
+        }
+
+        public async Task OnConnectedAsync(ConnectionContext connection)
+        {
+            try
+            {
+                var writer = new SpanBasedMqttPacketWriter();
+                var formatter = new MqttPacketFormatterAdapter(writer);
+                var context = new MqttConnectionContext(formatter, connection);
+                Context.TrySetResult(context);
+
+                await ClientHandler(context);
+            }
+            catch (Exception ex)
+            {
+                Context.TrySetException(ex);
+            }
+        }
+
+        public Task StartAsync(IMqttServerOptions options)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Tests/MQTTnet.AspNetCore.Tests/MqttConnectionContextTest.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/MqttConnectionContextTest.cs
@@ -1,13 +1,20 @@
-﻿using Microsoft.AspNetCore.Connections;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MQTTnet.AspNetCore.Tests.Mockups;
-using MQTTnet.Exceptions;
-using MQTTnet.Packets;
+
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using MQTTnet.Adapter;
+using MQTTnet.AspNetCore.Tests.Mockups;
+using MQTTnet.Client.Options;
+using MQTTnet.Exceptions;
 using MQTTnet.Formatter;
+using MQTTnet.Packets;
+using System.Net;
 
 namespace MQTTnet.AspNetCore.Tests
 {
@@ -62,6 +69,44 @@ namespace MQTTnet.AspNetCore.Tests
 
             var readResult = await pipe.Send.Reader.ReadAsync();
             Assert.IsTrue(readResult.Buffer.Length > 20000);
+        }
+
+        private class Startup 
+        {
+            public void Configure(IApplicationBuilder app)
+            { 
+            }
+        }
+
+        [TestMethod]
+        public async Task TestEndpoint()
+        {
+            var mockup = new ConnectionHandlerMockup();
+
+
+            using (var host = new WebHostBuilder()
+                .UseKestrel(kestrel => kestrel.ListenLocalhost(1883, listener => listener.Use((ctx, next) => mockup.OnConnectedAsync(ctx))))
+                .UseStartup<Startup>()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddHostedMqttServer(o => o.WithoutDefaultEndpoint());
+                    services.AddSingleton<IMqttServerAdapter>(mockup);
+                })
+                .Build())
+            using (var client = new MqttFactory().CreateMqttClient())
+            {
+                host.Start();
+                await client.ConnectAsync(new MqttClientOptionsBuilder()
+                    .WithTcpServer("localhost")
+                    .Build(), CancellationToken.None);
+
+                var ctx = await mockup.Context.Task;
+#if NETCOREAPP3_1
+                var ep = IPEndPoint.Parse(ctx.Endpoint);
+                Assert.IsNotNull(ep);
+#endif
+                Assert.IsNotNull(ctx);
+            }               
         }
     }
 }


### PR DESCRIPTION
In aspnet core, the connection(except websocket connection) is handle by MqttConnectionHandler, so the HttpContext instance allway is null, we should get Endpoint from IConnectionEndPointFeature.