### PR TITLE
Adjusted copyright information in the nuget package specifications.

### DIFF
--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is a support library to integrate MQTTnet into AspNetCore.</description>
     <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
-    <copyright>Copyright Christian Kratky 2016-2019</copyright>
+    <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags>
     <dependencies>
       <dependency id="MQTTnet" version="$nugetVersion" />

--- a/Build/MQTTnet.Extensions.ManagedClient.nuspec
+++ b/Build/MQTTnet.Extensions.ManagedClient.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is an extension library which provides a managed MQTT client with additional features using MQTTnet.</description>
     <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
-    <copyright>Copyright Christian Kratky 2016-2019</copyright>
+    <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
       <dependency id="MQTTnet" version="$nugetVersion" />

--- a/Build/MQTTnet.Extensions.Rpc.nuspec
+++ b/Build/MQTTnet.Extensions.Rpc.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is an extension library which allows executing synchronous device calls including a response using MQTTnet.</description>
     <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
-    <copyright>Copyright Christian Kratky 2016-2019</copyright>
+    <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
       <dependency id="MQTTnet" version="$nugetVersion" />

--- a/Build/MQTTnet.Extensions.WebSocket4Net.nuspec
+++ b/Build/MQTTnet.Extensions.WebSocket4Net.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This is an extension library which allows using _WebSocket4Net_ as transport for MQTTnet clients.</description>
     <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
-    <copyright>Copyright Christian Kratky 2016-2019</copyright>
+    <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
       <dependency id="MQTTnet" version="$nugetVersion" />

--- a/Build/MQTTnet.NETStandard.nuspec
+++ b/Build/MQTTnet.NETStandard.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This package contains the .NET Standard version of MQTTnet only.</description>
     <releaseNotes>For release notes please go to MQTTnet release notes (https://www.nuget.org/packages/MQTTnet/).</releaseNotes>
-    <copyright>Copyright Christian Kratky 2016-2019</copyright>
+    <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -23,7 +23,7 @@
 * [MQTTnet.Server] Added interceptor for unsubscriptions.
 * [MQTTnet.AspNetCore] improved compatibility with AspNetCore 3.1
     </releaseNotes>
-    <copyright>Copyright Christian Kratky 2016-2019</copyright>
+    <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 
     <dependencies>
       <group targetFramework="netstandard1.3">


### PR DESCRIPTION
Trivial change: I changed `2019` in the `<copyright>` section of the nuget packages to `2020`. I will just merge this because it doesn't affect anything else.