### PR TITLE
Support MqttClientOptionsBuilder.WithConnectionUri()

### DIFF
--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -22,6 +22,7 @@
 * [Server] Added interceptor for unsubscriptions.
 * [MQTTnet.Server] Added interceptor for unsubscriptions.
 * [MQTTnet.AspNetCore] improved compatibility with AspNetCore 3.1
+* [Client] Support WithConnectionUri to configure client (thanks to @PMExtra).
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin</tags> 

--- a/Source/MQTTnet/Extensions/MqttClientOptionsBuilderExtension.cs
+++ b/Source/MQTTnet/Extensions/MqttClientOptionsBuilderExtension.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using MQTTnet.Client.Options;
+
+namespace MQTTnet.Extensions
+{
+    public static class MqttClientOptionsBuilderExtension
+    {
+        public static MqttClientOptionsBuilder WithConnectionUri(this MqttClientOptionsBuilder builder, Uri uri)
+        {
+            var port = uri.IsDefaultPort ? null : (int?) uri.Port;
+            switch (uri.Scheme.ToLower())
+            {
+                case "tcp":
+                case "mqtt":
+                    builder.WithTcpServer(uri.Host, port);
+                    break;
+
+                case "mqtts":
+                    builder.WithTcpServer(uri.Host, port).WithTls();
+                    break;
+
+                case "ws":
+                case "wss":
+                    builder.WithWebSocketServer(uri.ToString());
+                    break;
+
+                default:
+                    throw new ArgumentException("Unexpected scheme in uri.");
+            }
+            
+            if (!string.IsNullOrEmpty(uri.UserInfo))
+            {
+                var userInfo = uri.UserInfo.Split(':');
+                var username = userInfo[0];
+                var password = userInfo.Length > 1 ? userInfo[1] : "";
+                builder.WithCredentials(username, password);
+            }
+
+            return builder;
+        }
+
+        public static MqttClientOptionsBuilder WithConnectionUri(this MqttClientOptionsBuilder builder, string uri)
+        {
+            return WithConnectionUri(builder, new Uri(uri, UriKind.Absolute));
+        }
+    }
+}

--- a/Tests/MQTTnet.Core.Tests/MqttClientOptionsBuilder_Tests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttClientOptionsBuilder_Tests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Client.Options;
+using MQTTnet.Extensions;
+
+namespace MQTTnet.Tests
+{
+    [TestClass]
+    public class MqttClientOptionsBuilder_Tests
+    {
+        [TestMethod]
+        public void WithConnectionUri_Credential_Test()
+        {
+            var options = new MqttClientOptionsBuilder()
+                .WithConnectionUri("mqtt://user:password@127.0.0.1")
+                .Build();
+            Assert.AreEqual("user", options.Credentials.Username);
+            Assert.IsTrue(Encoding.UTF8.GetBytes("password").SequenceEqual(options.Credentials.Password));
+        }
+    }
+}


### PR DESCRIPTION
A convenience way to configure server, port, username and password, example:
```
var options = new MqttClientOptionsBuilder()
    .WithConnectionUri("mqtt://user:password@127.0.0.1")
    .Build();
```

`mqtt://` and `mqtts://` are defined by MQTT official. (https://mqtt.org/wiki/URI-Scheme)
`ws://` and `wss://` are defined by [RFC8307](https://tools.ietf.org/html/rfc8307)

`tcp://` is commonly used.

The above 5 schemes are supported now.

I also have some other non-standardized idea like:
- [ ] `ssl://`
- [ ] `tls://`
- [ ] `mqtt+ws://`
- [ ] `mqtt+wss://`
- [ ] `mqtt+tcp://`
- [ ] `mqtt+ssl://`
- [ ] `mqtt+tls://`

Some of them could be added if you approve it.