### PR TITLE
Add an x509 certificate parameter

### DIFF
--- a/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
@@ -44,13 +44,17 @@ namespace MQTTnet.Implementations
 
             if (options.TlsEndpointOptions?.IsEnabled == true)
             {
-                if (options.TlsEndpointOptions.Certificate == null)
+                if (options.TlsEndpointOptions.Certificate == null && options.TlsEndpointOptions.X509Certificate == null)
                 {
                     throw new ArgumentException("TLS certificate is not set.");
                 }
 
                 X509Certificate2 tlsCertificate;
-                if (string.IsNullOrEmpty(options.TlsEndpointOptions.CertificateCredentials?.Password))
+                if (options.TlsEndpointOptions.X509Certificate != null)
+                {
+                    tlsCertificate = options.TlsEndpointOptions.X509Certificate;
+                }
+                else if (string.IsNullOrEmpty(options.TlsEndpointOptions.CertificateCredentials?.Password))
                 {
                     // Use a different overload when no password is specified. Otherwise the constructor will fail.
                     tlsCertificate = new X509Certificate2(options.TlsEndpointOptions.Certificate);

--- a/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerAdapter.cs
@@ -48,6 +48,10 @@ namespace MQTTnet.Implementations
                 {
                     throw new ArgumentException("TLS certificate is not set.");
                 }
+                else if (options.TlsEndpointOptions.Certificate != null && options.TlsEndpointOptions.X509Certificate != null)
+                {
+                    throw new ArgumentException($"{nameof(MqttServerTlsTcpEndpointOptions.Certificate)} and {nameof(MqttServerTlsTcpEndpointOptions.X509Certificate)} cannot both be set");
+                }
 
                 X509Certificate2 tlsCertificate;
                 if (options.TlsEndpointOptions.X509Certificate != null)

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -2,7 +2,9 @@
 using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
+#if !WINDOWS_UWP
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace MQTTnet.Server
 {

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Server
 {
@@ -86,6 +87,12 @@ namespace MQTTnet.Server
         {
             _options.TlsEndpointOptions.Certificate = value;
             _options.TlsEndpointOptions.CertificateCredentials = credentials;
+            return this;
+        }
+
+        public MqttServerOptionsBuilder WithEncryptionCertificate(X509Certificate2 certificate)
+        {
+            _options.TlsEndpointOptions.X509Certificate = certificate;
             return this;
         }
 

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -90,11 +90,13 @@ namespace MQTTnet.Server
             return this;
         }
 
+#if !WINDOWS_UWP
         public MqttServerOptionsBuilder WithEncryptionCertificate(X509Certificate2 certificate)
         {
             _options.TlsEndpointOptions.X509Certificate = certificate;
             return this;
         }
+#endif
 
         public MqttServerOptionsBuilder WithEncryptionSslProtocol(SslProtocols value)
         {

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -13,7 +13,9 @@ namespace MQTTnet.Server
 
         public byte[] Certificate { get; set; }
 
+#if !WINDOWS_UWP
         public X509Certificate2 X509Certificate { get; set; }
+#endif
 
         public IMqttServerCertificateCredentials CertificateCredentials { get; set; }
 

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net.Security;
 using System.Security.Authentication;
+#if !WINDOWS_UWP
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace MQTTnet.Server
 {

--- a/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerTlsTcpEndpointOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MQTTnet.Server
 {
@@ -11,6 +12,8 @@ namespace MQTTnet.Server
         }
 
         public byte[] Certificate { get; set; }
+
+        public X509Certificate2 X509Certificate { get; set; }
 
         public IMqttServerCertificateCredentials CertificateCredentials { get; set; }
 


### PR DESCRIPTION
First, thanks for your maintaining this project. I appreciate it

I'm resubmitting #797 as I don't understand why it was closed without comment. If it's not functionality that's useful to others, please let me know. Based on #800 with similar cert changes but for client side being submitted shortly after my server side cert changes, it seems likely others might be interested. Either way, it's functionality that I need, so I know I would appreciate it being merged so I can stop maintaining a separate fork

Closes #796

Adds a way to set the server's certificate using an X509Certificate2 directly instead of needing to export it to byte[].

Thanks again for your time