### PR TITLE
removed unused dependecies

### DIFF
--- a/Build/MQTTnet.AspNetCore.nuspec
+++ b/Build/MQTTnet.AspNetCore.nuspec
@@ -17,15 +17,11 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="MQTTnet" version="$nugetVersion" />
-        <dependency id="Microsoft.AspNetCore.Connections.Abstractions" version="3.1.3" />
-        <dependency id="Microsoft.AspNetCore.Http.Connections" version="1.1.0"  />
-        <dependency id="Microsoft.AspNetCore.WebSockets" version="2.2.1" />
-        <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="3.1.3" />
+        <dependency id="Microsoft.AspNetCore.Http.Connections" version="1.0.0"  />
       </group>
       
       <group targetFramework="netcoreapp3.1">
         <dependency id="MQTTnet" version="$nugetVersion" />
-        <dependency id="System.IO.Pipelines" version="4.7.1" />
       </group>
     </dependencies>
   </metadata>

--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -20,7 +20,7 @@
 * [Client] Fixed an issue when connecting to an invalid host (format).
 * [ManagedClient] Added method to trigger PING/PONG manually (connection check etc.).
 * [MQTTnet.AspNetCore] improved compatibility with AspNetCore 3.1.
-* [MQTTnet.AspNetCore] Fixed a packaging issue with the Nuget package.
+* [MQTTnet.AspNetCore] Fixed several packaging issues with the Nuget package.
 * [MQTTnet.Server] Fixed wrong version output.
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2020</copyright>

--- a/Source/MQTTnet.AspnetCore/Client/Tcp/TcpConnection.cs
+++ b/Source/MQTTnet.AspnetCore/Client/Tcp/TcpConnection.cs
@@ -43,7 +43,7 @@ namespace MQTTnet.AspNetCore.Client.Tcp
 #if NETCOREAPP3_1
         public override ValueTask DisposeAsync()
 #else
-        public new Task DisposeAsync()
+        public Task DisposeAsync()
 #endif
         {
             IsConnected = false;

--- a/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
+++ b/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
@@ -16,15 +16,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.1" />
   </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MQTTnet.TestApp.AspNetCore2/MQTTnet.TestApp.AspNetCore2.csproj
+++ b/Tests/MQTTnet.TestApp.AspNetCore2/MQTTnet.TestApp.AspNetCore2.csproj
@@ -8,19 +8,14 @@
   <ItemGroup>
     <Content Remove="wwwroot\app\app.ts" />
   </ItemGroup>
-
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.3" />
-  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\Source\MQTTnet.AspnetCore\MQTTnet.AspNetCore.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
discussion in #908 removed unneccesary package references

I dont know why there have been so many package references. I dumped them down to the bare minimum again. that way the nuget should work for aspnet 2.1 to 3.1.

(it did before but also pulled in some 3.1 packages when running in aspnet 2.1 which is not harmful but unnessesary)

