### PR TITLE
CrossPlatformSocket: Added SocketOptionName.ReuseAddress = true.

### DIFF
--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -16,8 +16,9 @@
 * [AspNetCore] Adjusted some namespaces (BREAKING CHANGE!)
 * [Server] Adjusted some namespaces (BREAKING CHANGE!)
 * [Server] Added state checks (throw if not started etc.) for most server APIs.
-* [Server] Exposed real X509Certificate2 (instead byte array) to TLS options (thanks to @borigas).
+* [Server] Exposed real X509Certificate2 (instead byte array) to TLS options (Thanks to @borigas).
 * [Core] Fixed a null reference exception in the MqttTcpChannel with WriteAsync and ReadAsync.
+* [Core] Fixed reusing of sockets (Thanks to @zvrba).
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</tags> 

--- a/Source/MQTTnet/Implementations/CrossPlatformSocket.cs
+++ b/Source/MQTTnet/Implementations/CrossPlatformSocket.cs
@@ -86,6 +86,7 @@ namespace MQTTnet.Implementations
         {
             if (localEndPoint is null) throw new ArgumentNullException(nameof(localEndPoint));
 
+            _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             _socket.Bind(localEndPoint);
         }
 


### PR DESCRIPTION
Fixes https://github.com/chkr1011/MQTTnet/issues/494 (At least as far as I understood it).
Suggestion from @zvrba.

Might also fix https://github.com/chkr1011/MQTTnet/issues/872.