### PR TITLE
improve exceptions in case of corrupt packages

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -145,6 +145,13 @@ namespace MQTTnet.AspNetCore
                     }
                 }
             }
+            catch (Exception e)
+            {
+                // completing the cannels makes sure that there is no more data read after a protocol error
+                _input?.Complete(e);
+                _output?.Complete(e);
+                throw;
+            }
             finally
             {
                 ReadingPacketCompletedCallback?.Invoke();

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketBodyReader.cs
@@ -117,6 +117,10 @@ namespace MQTTnet.AspNetCore
             var span = _buffer.Span;
             var length = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(_offset));
 
+            if (Length < _offset + length)
+            {
+                throw new MqttProtocolViolationException($"Expected at least {_offset + 2 + length} bytes but there are only {Length} bytes");
+            }
             var result = span.Slice(_offset + 2, length);
             _offset += 2 + length;
             return result;

--- a/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketWriter.cs
+++ b/Source/MQTTnet.AspnetCore/SpanBasedMqttPacketWriter.cs
@@ -10,6 +10,11 @@ namespace MQTTnet.AspNetCore
     {
         readonly ArrayPool<byte> _pool = ArrayPool<byte>.Create();
 
+        public SpanBasedMqttPacketWriter()
+        {
+            Reset(0);
+        }
+
         byte[] _buffer;
         int _position;
 

--- a/Source/MQTTnet/Formatter/MqttPacketBodyReader.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketBodyReader.cs
@@ -134,7 +134,7 @@ namespace MQTTnet.Formatter
         {
             if (_length < _offset + length)
             {
-                throw new ArgumentOutOfRangeException(nameof(_buffer), $"Expected at least {_offset + length} bytes but there are only {_length} bytes");
+                throw new MqttProtocolViolationException($"Expected at least {_offset + length} bytes but there are only {_length} bytes");
             }
         }
 

--- a/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
@@ -120,6 +120,14 @@ namespace MQTTnet.Formatter
         {
             if (receivedMqttPacket == null) throw new ArgumentNullException(nameof(receivedMqttPacket));
 
+            if (receivedMqttPacket.Body.Length < 7)
+            {
+                // 2 byte protocol name length
+                // at least 4 byte protocol name
+                // 1 byte protocol level
+                throw new MqttProtocolViolationException("Mqtt Connect packet must have at least 7 bytes");
+            }
+
             var protocolName = receivedMqttPacket.Body.ReadStringWithLengthPrefix();
             var protocolLevel = receivedMqttPacket.Body.ReadByte();
 

--- a/Tests/MQTTnet.AspNetCore.Tests/SpanBasedMqttPacketWriterTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Tests/SpanBasedMqttPacketWriterTests.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Formatter;
+using MQTTnet.Tests;
+
+namespace MQTTnet.AspNetCore.Tests
+{
+    [TestClass]
+    public class SpanBasedMqttPacketWriterTests : MqttPacketWriter_Tests
+    {
+        protected override IMqttPacketWriter WriterFactory()
+        {
+            return new SpanBasedMqttPacketWriter();
+        }
+    }
+}

--- a/Tests/MQTTnet.Core.Tests/Extensions/MqttPacketWriterExtensions.cs
+++ b/Tests/MQTTnet.Core.Tests/Extensions/MqttPacketWriterExtensions.cs
@@ -1,0 +1,15 @@
+﻿using MQTTnet.Protocol;
+
+namespace MQTTnet.Formatter
+{
+    public static class MqttPacketWriterExtensions
+    {
+        public static byte[] AddMqttHeader(this IMqttPacketWriter writer, MqttControlPacketType header, byte[] body)
+        {
+            writer.Write(MqttPacketWriter.BuildFixedHeader(header));
+            writer.WriteVariableLengthInteger((uint)body.Length);
+            writer.Write(body, 0, body.Length);
+            return writer.GetBuffer();
+        }
+    }
+}

--- a/Tests/MQTTnet.Core.Tests/MqttPacketWriter_Tests.cs
+++ b/Tests/MQTTnet.Core.Tests/MqttPacketWriter_Tests.cs
@@ -6,10 +6,15 @@ namespace MQTTnet.Tests
     [TestClass]
     public class MqttPacketWriter_Tests
     {
+        protected virtual IMqttPacketWriter WriterFactory()
+        {
+            return new MqttPacketWriter();
+        }
+
         [TestMethod]
         public void WritePacket()
         {
-            var writer = new MqttPacketWriter();
+            var writer = WriterFactory();
             Assert.AreEqual(0, writer.Length);
 
             writer.WriteWithLengthPrefix("1234567890");


### PR DESCRIPTION
and close pipes after exception occoured to avoid lingering connections should fix #788

@chkr1011 i was not able to reproduce the high cpu load. but i added some testcases and unified the api behavior when dealing with corrupt packages.

I dont quite like the error message that is checking for at least 7 bytes if you have a better idea let me know.

the only thing I found was that if for some reason the clientSessionmanager would call ReceiveAsync after an exception the asp.net connection would still try to read data, thats why explicitly close them now when an exception was thrown. this should however in practise not make a difference as the clientSessionmanager should exit its loop if the first exception is thrown and thus let kestrel cleanup the connection