### PR TITLE
Tried to add a MqttServerOptions fluent method for the client disconn…

### DIFF
--- a/Source/MQTTnet/Server/IMqttServerOptions.cs
+++ b/Source/MQTTnet/Server/IMqttServerOptions.cs
@@ -27,5 +27,7 @@ namespace MQTTnet.Server
         IMqttRetainedMessagesManager RetainedMessagesManager { get; }
 
         IMqttServerApplicationMessageInterceptor UndeliveredMessageInterceptor { get; set; }
+
+        IMqttServerClientDisconnectedHandler ClientDisconnectedInterceptor { get; set; }
     }
 }

--- a/Source/MQTTnet/Server/MqttServerClientDisconnectedHandlerDelegate.cs
+++ b/Source/MQTTnet/Server/MqttServerClientDisconnectedHandlerDelegate.cs
@@ -5,27 +5,27 @@ namespace MQTTnet.Server
 {
     public class MqttServerClientDisconnectedHandlerDelegate : IMqttServerClientDisconnectedHandler
     {
-        private readonly Func<MqttServerClientDisconnectedEventArgs, Task> _handler;
+        private readonly Func<MqttServerClientDisconnectedEventArgs, Task> _callback;
 
-        public MqttServerClientDisconnectedHandlerDelegate(Action<MqttServerClientDisconnectedEventArgs> handler)
+        public MqttServerClientDisconnectedHandlerDelegate(Action<MqttServerClientDisconnectedEventArgs> callback)
         {
-            if (handler == null) throw new ArgumentNullException(nameof(handler));
+            if (callback == null) throw new ArgumentNullException(nameof(callback));
 
-            _handler = eventArgs =>
+            _callback = eventArgs =>
             {
-                handler(eventArgs);
+                callback(eventArgs);
                 return Task.FromResult(0);
             };
         }
 
-        public MqttServerClientDisconnectedHandlerDelegate(Func<MqttServerClientDisconnectedEventArgs, Task> handler)
+        public MqttServerClientDisconnectedHandlerDelegate(Func<MqttServerClientDisconnectedEventArgs, Task> callback)
         {
-            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _callback = callback ?? throw new ArgumentNullException(nameof(callback));
         }
 
         public Task HandleClientDisconnectedAsync(MqttServerClientDisconnectedEventArgs eventArgs)
         {
-            return _handler(eventArgs);
+            return _callback(eventArgs);
         }
     }
 }

--- a/Source/MQTTnet/Server/MqttServerClientDisconnectedHandlerDelegate.cs
+++ b/Source/MQTTnet/Server/MqttServerClientDisconnectedHandlerDelegate.cs
@@ -5,27 +5,27 @@ namespace MQTTnet.Server
 {
     public class MqttServerClientDisconnectedHandlerDelegate : IMqttServerClientDisconnectedHandler
     {
-        private readonly Func<MqttServerClientDisconnectedEventArgs, Task> _callback;
+        private readonly Func<MqttServerClientDisconnectedEventArgs, Task> _handler;
 
-        public MqttServerClientDisconnectedHandlerDelegate(Action<MqttServerClientDisconnectedEventArgs> callback)
+        public MqttServerClientDisconnectedHandlerDelegate(Action<MqttServerClientDisconnectedEventArgs> handler)
         {
-            if (callback == null) throw new ArgumentNullException(nameof(callback));
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
 
-            _callback = eventArgs =>
+            _handler = eventArgs =>
             {
-                callback(eventArgs);
+                handler(eventArgs);
                 return Task.FromResult(0);
             };
         }
 
-        public MqttServerClientDisconnectedHandlerDelegate(Func<MqttServerClientDisconnectedEventArgs, Task> callback)
+        public MqttServerClientDisconnectedHandlerDelegate(Func<MqttServerClientDisconnectedEventArgs, Task> handler)
         {
-            _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
         public Task HandleClientDisconnectedAsync(MqttServerClientDisconnectedEventArgs eventArgs)
         {
-            return _callback(eventArgs);
+            return _handler(eventArgs);
         }
     }
 }

--- a/Source/MQTTnet/Server/MqttServerOptions.cs
+++ b/Source/MQTTnet/Server/MqttServerOptions.cs
@@ -33,5 +33,7 @@ namespace MQTTnet.Server
         public IMqttRetainedMessagesManager RetainedMessagesManager { get; set; } = new MqttRetainedMessagesManager();
 
         public IMqttServerApplicationMessageInterceptor UndeliveredMessageInterceptor { get; set; }
+
+        public IMqttServerClientDisconnectedHandler ClientDisconnectedInterceptor { get; set; }
     }
 }

--- a/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/MqttServerOptionsBuilder.cs
@@ -163,6 +163,18 @@ namespace MQTTnet.Server
             return this;
         }
 
+        public MqttServerOptionsBuilder WithDisconnectedInterceptor(IMqttServerClientDisconnectedHandler value)
+        {
+            _options.ClientDisconnectedInterceptor = value;
+            return this;
+        }
+
+        public MqttServerOptionsBuilder WithDisconnectedInterceptor(Action<MqttServerClientDisconnectedEventArgs> value)
+        {
+            _options.ClientDisconnectedInterceptor = new MqttServerClientDisconnectedHandlerDelegate(value);
+            return this;
+        }
+
         public MqttServerOptionsBuilder WithApplicationMessageInterceptor(IMqttServerApplicationMessageInterceptor value)
         {
             _options.ApplicationMessageInterceptor = value;


### PR DESCRIPTION
…ected handler.

@chkr1011 and @JanEggers: I wanted to add the disconnected handler within the `fluent calls` like `WithApplicationMessageInterceptor` and so on. Can you guide me on what's missing, please? It seems like there is something I didn't understand there... (The disconnected handler is somewhere else already getting called).