### PR TITLE
improved behavior when multiple connections fight over a session

### DIFF
--- a/Build/MQTTnet.nuspec
+++ b/Build/MQTTnet.nuspec
@@ -14,8 +14,10 @@
     <releaseNotes>
 * [Client] Fixed wrong value for "ClientWasConnected" in "MqttClientDisconnectedEventArgs" #976 (thanks to @dbeinder).
 * [Client] Added direct support for Amazon AWS connections (requires .NET Core 3.1) (thanks to @henning-krause).
+* [Client] handle disconnect package and propagate disconnect reason code (thanks to @JanEggers)
 * [ManagedClient] Exposed the internal MQTT client.
-* [Server] Added client message queue interceptor for QoS level (tahnks to @msallin).
+* [Server] Added client message queue interceptor for QoS level (thanks to @msallin).
+* [Server] improved behavior when multiple connections fight over a session (thanks to @JanEggers)
     </releaseNotes>
     <copyright>Copyright Christian Kratky 2016-2020</copyright>
     <tags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</tags> 

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -561,7 +561,7 @@ namespace MQTTnet.Client
                 {
                     await SendAsync(new MqttPingRespPacket(), cancellationToken).ConfigureAwait(false);
                 }
-                else if (packet is MqttDisconnectPacket disc)
+                else if (packet is MqttDisconnectPacket disconnectPacket)
                 {
                     // Also dispatch disconnect to waiting threads to generate a proper exception.
                     _packetDispatcher.Dispatch(packet);
@@ -569,7 +569,7 @@ namespace MQTTnet.Client
                     await DisconnectAsync(new MqttClientDisconnectOptions() 
                     {
                         // todo conversion
-                        ReasonCode = disc.ReasonCode
+                        ReasonCode = (MqttClientDisconnectReason)(disconnectPacket.ReasonCode ?? MqttDisconnectReasonCode.UnspecifiedError)
                     }, cancellationToken).ConfigureAwait(false);
                 }
                 else if (packet is MqttAuthPacket authPacket)

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -568,7 +568,6 @@ namespace MQTTnet.Client
 
                     await DisconnectAsync(new MqttClientDisconnectOptions() 
                     {
-                        // todo conversion
                         ReasonCode = (MqttClientDisconnectReason)(disconnectPacket.ReasonCode ?? MqttDisconnectReasonCode.UnspecifiedError)
                     }, cancellationToken).ConfigureAwait(false);
                 }

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -561,12 +561,16 @@ namespace MQTTnet.Client
                 {
                     await SendAsync(new MqttPingRespPacket(), cancellationToken).ConfigureAwait(false);
                 }
-                else if (packet is MqttDisconnectPacket)
+                else if (packet is MqttDisconnectPacket disc)
                 {
                     // Also dispatch disconnect to waiting threads to generate a proper exception.
                     _packetDispatcher.Dispatch(packet);
 
-                    await DisconnectAsync(null, cancellationToken).ConfigureAwait(false);
+                    await DisconnectAsync(new MqttClientDisconnectOptions() 
+                    {
+                        // todo conversion
+                        ReasonCode = disc.ReasonCode
+                    }, cancellationToken).ConfigureAwait(false);
                 }
                 else if (packet is MqttAuthPacket authPacket)
                 {

--- a/Source/MQTTnet/Server/MqttClientConnection.cs
+++ b/Source/MQTTnet/Server/MqttClientConnection.cs
@@ -257,6 +257,15 @@ namespace MQTTnet.Server
                     Session.WillMessage = null;
                 }
 
+                if (_isTakeover)
+                {
+                    // dont use SendAsync here _cancellationToken is already cancelled
+                    await _channelAdapter.SendPacketAsync(new MqttDisconnectPacket()
+                    {
+                        ReasonCode = MqttDisconnectReasonCode.SessionTakenOver
+                    }, TimeSpan.Zero, CancellationToken.None).ConfigureAwait(false);
+                }
+
                 _packetDispatcher.Reset();
 
                 _channelAdapter.ReadingPacketStartedCallback = null;

--- a/Source/MQTTnet/Server/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/MqttClientSessionsManager.cs
@@ -391,9 +391,9 @@ namespace MQTTnet.Server
                 _connections.AddOrUpdate(connectPacket.ClientId, key => 
                 {
                     return connection;
-                }, (key, tempexistingConnection) =>
+                }, (key, tempExistingConnection) =>
                 {
-                    existingConnection = tempexistingConnection;
+                    existingConnection = tempExistingConnection;
                     return connection;
                 });
 


### PR DESCRIPTION
improvements / fixes for #990 

there is still an issue in the client. right now the client throws argumentnullexception when receiving a diconnect packet.

i added the required options class but there is an enum collision.

Does a conversion for the reason codes exist?