### PR TITLE
Fix: Compile error, cancellation token removed since the method does not support it

### DIFF
--- a/Source/MQTTnet/Server/MqttClientConnection.cs
+++ b/Source/MQTTnet/Server/MqttClientConnection.cs
@@ -456,7 +456,7 @@ namespace MQTTnet.Server
                             {
                                 PacketIdentifier = publishPacket.PacketIdentifier,
                                 ReasonCode = MqttPubRelReasonCode.Success
-                            }, cancellationToken).ConfigureAwait(false);
+                            }).ConfigureAwait(false);
 
                             await awaiter2.WaitOneAsync(_serverOptions.DefaultCommunicationTimeout).ConfigureAwait(false);
                         }


### PR DESCRIPTION
This fixes the current issue why it's not compiling.

Cancellation token removed because the SendAsync() method does not support it.