### PR TITLE
The topic filter comparer now checks for e.g. "foo/" matching "foo/#".

### DIFF
--- a/Source/MQTTnet/Server/MqttTopicFilterComparer.cs
+++ b/Source/MQTTnet/Server/MqttTopicFilterComparer.cs
@@ -31,6 +31,13 @@ namespace MQTTnet.Server
                         {
                             return true;
                         }
+                        // Check for e.g. foo/ matching foo/#
+                        if (sPos == sLen - 2
+                                && filter[sPos] == LevelSeparator
+                                && filter[sPos + 1] == MultiLevelWildcard)
+                        {
+                            return true;
+                        }
                     }
 
                     sPos++;

--- a/Tests/MQTTnet.Core.Tests/TopicFilterComparer_Tests.cs
+++ b/Tests/MQTTnet.Core.Tests/TopicFilterComparer_Tests.cs
@@ -55,6 +55,12 @@ namespace MQTTnet.Tests
         }
 
         [TestMethod]
+        public void TopicFilterComparer_EndMultipleLevelsWildcardMatchEmptyLevel()
+        {
+            CompareAndAssert("A/", "A/#", true);
+        }
+
+        [TestMethod]
         public void TopicFilterComparer_AllLevelsWildcardMatch()
         {
             CompareAndAssert("A/B/C/D", "#", true);


### PR DESCRIPTION
The topic filter comparer now checks for e.g. `foo/` matching `foo/#`.

Fixes #1067.
