### PR TITLE
Added workflow to  build debian/ubuntu packages

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -1,0 +1,67 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Deb Packaging
+
+# Controls when the action will run. 
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      FileVersion:
+        description: 'File Version'
+        required: true
+        default: ''
+      Version:
+        description: 'Version'
+        required: true
+        default: ''
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build MQTTnetServer
+        run: dotnet publish Source/MQTTnet.Server/MQTTnet.Server.csproj --configuration Release /p:FileVersion=${{ github.event.inputs.fileVersion }} /p:Version=${{ github.event.inputs.version }} --self-contained --runtime linux-x64 --framework net5.0
+
+      - name: Set up installation directory
+        run: mkdir -p packaging/opt/MQTTnetServer
+
+      - name: Copy meta data
+        run: |
+          cp -R Build/deb-meta/* packaging/
+          chmod 755 packaging/DEBIAN/postinst
+          chmod 755 packaging/DEBIAN/postrm
+
+      - name: Move artifacts to packaging directory
+        run: cp -R Source/MQTTnet.Server/bin/Release/net5.0/linux-x64/publish/* packaging/opt/MQTTnetServer
+
+      - name: Adjust files
+        run: |
+          rm packaging/opt/MQTTnetServer/appsettings.Development.json
+          mv packaging/opt/MQTTnetServer/appsettings.json packaging/opt/MQTTnetServer/appsettings.template.json
+
+      - name: Adjust permissions
+        run: |
+          cd packaging/opt/MQTTnetServer
+          find . -type f | xargs chmod -R 644
+          chmod 755 MQTTnet.Server
+
+      - name: Generate MD5s
+        run: |
+          cd packaging/          
+          md5sum $(find * -type f -not -path 'DEBIAN/*') > DEBIAN/md5sums
+      
+      - name: Patch meta
+        run: sed -i 's/\$VERSION/${{ github.event.inputs.version }}/' packaging/DEBIAN/control
+
+      - name: Package everything
+        run: dpkg-deb -v --build packaging/ mqttnet-server_${{ github.event.inputs.version }}.deb
+      
+      - name: Save artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: mqttnet-server
+          path: mqttnet-server_${{ github.event.inputs.version }}.deb

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -59,7 +59,7 @@ jobs:
         run: sed -i 's/\$VERSION/${{ github.event.inputs.version }}/' packaging/DEBIAN/control
 
       - name: Package everything
-        run: dpkg-deb -v --build packaging/ mqttnet-server_${{ github.event.inputs.version }}.deb
+        run: dpkg-deb -v --build packaging/ mqttnet-server_${{ github.event.inputs.version }}-1_amd64.deb
       
       - name: Save artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -65,4 +65,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: mqttnet-server
-          path: mqttnet-server_${{ github.event.inputs.version }}.deb
+          path: mqttnet-server_${{ github.event.inputs.version }}-1_amd64.deb

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -34,6 +34,7 @@ jobs:
           cp -R Build/deb-meta/* packaging/
           chmod 755 packaging/DEBIAN/postinst
           chmod 755 packaging/DEBIAN/postrm
+          chmod 755 packaging/DEBIAN/prerm
 
       - name: Move artifacts to packaging directory
         run: cp -R Source/MQTTnet.Server/bin/Release/net5.0/linux-x64/publish/* packaging/opt/MQTTnetServer

--- a/Build/deb-meta/DEBIAN/control
+++ b/Build/deb-meta/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: mqttnet-server
+Version: $VERSION
+Section: base
+Priority: optional
+Architecture: amd64
+Depends:
+Suggests:
+Maintainer: Damian Wolgast <packages@asymetrixs.net>
+Description:
+  MQTTnet Server is a standalone cross platform MQTT server (like mosquitto) basing on this library.

--- a/Build/deb-meta/DEBIAN/copyright
+++ b/Build/deb-meta/DEBIAN/copyright
@@ -1,0 +1,26 @@
+The source of MQTTnet is at:
+https://github.com/chkr1011/MQTTnet
+Project is maintained by Christian Kratky
+
+
+MIT License
+
+Copyright (c) 2021 Damian Wolgast
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Build/deb-meta/DEBIAN/postinst
+++ b/Build/deb-meta/DEBIAN/postinst
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if user exits
+USER=mqttnetsrv
+USEREXISTS=$(id -u $USER >/dev/null 2>&1; echo $?)
+EC=0
+BASEPATH=/opt
+INSTALLPATH=$BASEPATH/MQTTnetServer
+
+# If user does not exist, create it
+if (( $USEREXISTS == 1 )); then
+        useradd -d $INSTALLPATH -m -r $USER
+        EC=$(echo $?)
+
+        if (( $EC == 1 )); then
+                exit 1;
+        fi
+fi
+
+# Set permissions on files
+chown -R root:root $INSTALLPATH
+
+# Check if config does not exist and create it
+if [ ! -f "$INSTALLPATH/appsettings.json" ]; then
+    cp $INSTALLPATH/appsettings.template.json $INSTALLPATH/appsettings.json
+fi
+
+# Enable MQTTServer.NET to bind to IP interface
+setcap CAP_NET_BIND_SERVICE=+eip $INSTALLPATH/MQTTnet.Server
+
+chmod 644 /etc/systemd/system/mqttnet-server.service
+
+# Reload systemd because of new service file
+systemctl daemon-reload

--- a/Build/deb-meta/DEBIAN/postrm
+++ b/Build/deb-meta/DEBIAN/postrm
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Reload systemd because of absent service file
+systemctl daemon-reload

--- a/Build/deb-meta/DEBIAN/prerm
+++ b/Build/deb-meta/DEBIAN/prerm
@@ -3,5 +3,8 @@
 BASEPATH=/opt
 INSTALLPATH=$BASEPATH/MQTTnetServer
 
+# Stop service before uninstalling
+systemctl stop mqttnet-server
+
 # Remove permission to open ports
 setcap CAP_NET_BIND_SERVICE=-eip $INSTALLPATH/MQTTnet.Server

--- a/Build/deb-meta/DEBIAN/prerm
+++ b/Build/deb-meta/DEBIAN/prerm
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BASEPATH=/opt
+INSTALLPATH=$BASEPATH/MQTTnetServer
+
+# Remove permission to open ports
+setcap CAP_NET_BIND_SERVICE=-eip $INSTALLPATH/MQTTnet.Server

--- a/Build/deb-meta/etc/systemd/system/mqttnet-server.service
+++ b/Build/deb-meta/etc/systemd/system/mqttnet-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=MQTTnetServer
+After=network.target
+
+[Service]
+ExecStart=/opt/MQTTnetServer/MQTTnet.Server
+WorkingDirectory=/opt/MQTTnetServer
+StandardOutput=inherit
+StandardError=inherit
+Restart=always
+User=mqttnetsrv
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This workflow generates MQTTnet.Server as debian package which can be easily installed on Ubuntu.
It puts a systemd service file in place to manage MQTTnet.Server as a systemd service.
It witelists the MQTTnet.Server executable to open ports on local IP interfaces.
Copyright of course can be adjusted.

A problem with Version and File Version exists, right now the workflow requests these values from the user executing the workflow. This should be improved. If it is the same for both, it could be taken from Tags if available.