### PR TITLE
Fixed `MqttNetLogLevel.Verbose` incorrectly mapped to `LogLevel.Debug`

### DIFF
--- a/Source/MQTTnet.Server/Logging/MqttNetLoggerWrapper.cs
+++ b/Source/MQTTnet.Server/Logging/MqttNetLoggerWrapper.cs
@@ -55,7 +55,7 @@ namespace MQTTnet.Server.Logging
                 case MqttNetLogLevel.Error: return LogLevel.Error;
                 case MqttNetLogLevel.Warning: return LogLevel.Warning;
                 case MqttNetLogLevel.Info: return LogLevel.Information;
-                case MqttNetLogLevel.Verbose: return LogLevel.Debug;
+                case MqttNetLogLevel.Verbose: return LogLevel.Trace;
             }
 
             return LogLevel.Debug;


### PR DESCRIPTION
Based on https://github.com/chkr1011/MQTTnet/issues/1138#issuecomment-846649937