### PR TITLE
Retrieving authentication result from ReconnectAsync helpers

### DIFF
--- a/Source/MQTTnet/Client/MqttClientExtensions.cs
+++ b/Source/MQTTnet/Client/MqttClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿using MQTTnet.Client.Connecting;
+using MQTTnet.Client.Connecting;
 using MQTTnet.Client.Disconnecting;
 using MQTTnet.Client.ExtendedAuthenticationExchange;
 using MQTTnet.Client.Options;
@@ -112,7 +112,7 @@ namespace MQTTnet.Client
             return client;
         }
 
-        public static Task ReconnectAsync(this IMqttClient client)
+        public static Task<MqttClientAuthenticateResult> ReconnectAsync(this IMqttClient client)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
@@ -122,6 +122,18 @@ namespace MQTTnet.Client
             }
 
             return client.ConnectAsync(client.Options);
+        }
+
+        public static Task<MqttClientAuthenticateResult> ReconnectAsync(this IMqttClient client, CancellationToken cancellationToken)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            if (client.Options == null)
+            {
+                throw new InvalidOperationException("_ReconnectAsync_ can be used only if _ConnectAsync_ was called before.");
+            }
+
+            return client.ConnectAsync(client.Options, cancellationToken);
         }
 
         public static Task DisconnectAsync(this IMqttClient client)


### PR DESCRIPTION
# Summary of changes
* Updated _MQTTnet.Client.MqttClientExtensions.ReconnectAsync_ method to return authentication result from underlying _client.ConnectAsync_ call
* Created an overload for _MQTTnet.Client.MqttClientExtensions.ReconnectAsync_ method that accepts cancellation tokens as an input parameter

## Reasons behind the changes
I found this lack of API during unification of connectivity issues handling logic in my projects that uses MQTTnet.
This change will allow me to find out if attempt to reconnect was successful, and if not - what was the reason:
```
var result = await client.ReconnectAsync();
if (result.ResultCode != MqttClientConnectResultCode.Success) {
   ... handle the issue, retry one more time etc...
}
```
Hopefully it makes sense.

Let me know if there is anything else I should improve to get this PR merged into MQTTnet repo.

Thanks!