### PR TITLE
Remove forced TLS 1.3 for client

### DIFF
--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
@@ -19,11 +19,7 @@ namespace MQTTnet.Client.Options
 
         public Func<MqttClientCertificateValidationCallbackContext, bool> CertificateValidationHandler { get; set; }
 
-#if NETCOREAPP3_1 || NET5_0
-        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls13;
-#else
-        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
-#endif
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.None;
 
 #if WINDOWS_UWP
         public IEnumerable<IEnumerable<byte>> Certificates { get; set; }

--- a/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Security;
 using System.Security.Authentication;
@@ -26,11 +26,7 @@ namespace MQTTnet.Client.Options
         public List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 #endif
 
-#if NETCOREAPP3_1 || NET5_0
-        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls13;
-#else
-        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
-#endif
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.None;
 
         [Obsolete("This property will be removed soon. Use CertificateValidationHandler instead.")]
         public Func<X509Certificate, X509Chain, SslPolicyErrors, IMqttClientOptions, bool> CertificateValidationCallback { get; set; }


### PR DESCRIPTION
Currently, when using an up to date version of .NET, the client defaults to only supporting TLS 1.3.
This is not expected behaviour for most users, all secure protocols should be allowed by default when connecting to a server.

If you have a TLS 1.2-only server and do a minor upgrade from MQTTnet <3.0.14 to >= 3.0.14, your connections (using default settings) just fail with an exception.

The new default value `SslProtocols.None` causes the OS to decide which protocols are allowed and as stated in https://docs.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-5.0 this is the preferred way of choosing protocols.

this fixes #1095, #1231, #1207, #1211

(also, as a side note, I'd be grateful if this PR was marked with the "hacktoberfest-accepted"-label to have this count as a valid PR)