### PR TITLE
Add message throughput test to NetCore Test App

### DIFF
--- a/Tests/MQTTnet.TestApp.NetCore/MessageThroughputTest.cs
+++ b/Tests/MQTTnet.TestApp.NetCore/MessageThroughputTest.cs
@@ -1,0 +1,341 @@
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
+using MQTTnet.Server;
+using System.Collections.Generic;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace MQTTnet.TestApp.NetCore
+{
+    /// <summary>
+    /// Connect a number of publisher clients and one subscriber client, then publish messages and measure
+    /// the number of messages per second that can be exchanged between publishers and subscriber.
+    /// Measurements are performed for subscriptions containing no wildcard, a single wildcard or multiple wildcards.
+    /// </summary>
+    public class MessageThroughputTest
+    {
+        // Change these constants to suit
+        const int NumPublishers = 5000;
+        const int NumTopicsPerPublisher = 10;
+
+        // Note: Other code changes may be required when changing this constant:
+        const int NumSubscribers = 1; // Fixed
+
+        // Number of publish calls before a response for all published messages is awaited.
+        // This must be limited to a reasonable value that the server or TCP pipeline can handle.
+        const int NumPublishCallsPerBatch = 250;
+
+        // Message counters are set/reset in the PublishAllAsync loop
+        int _messagesReceivedCount;
+        int _messagesExpectedCount;
+
+        CancellationTokenSource _cancellationTokenSource;
+
+        IMqttServer _mqttServer;
+        Dictionary<string, IMqttClient> _mqttPublisherClientsByPublisherName;
+        List<IMqttClient> _mqttSubscriberClients;
+
+        Dictionary<string, List<string>> _topicsByPublisher;
+        Dictionary<string, List<string>> _singleWildcardTopicsByPublisher;
+        Dictionary<string, List<string>> _multiWildcardTopicsByPublisher;
+
+        public async Task Run()
+        {
+            try
+            {
+                Console.WriteLine();
+                Console.WriteLine("Begin message throughput test");
+                Console.WriteLine();
+
+                Console.WriteLine("Number of publishers: " + NumPublishers);
+                Console.WriteLine("Number of published topics (total): " + NumPublishers * NumTopicsPerPublisher);
+                Console.WriteLine("Number of subscribers: " + NumSubscribers);
+
+                await Setup();
+
+                await Subscribe_to_No_Wildcard_Topics();
+                await Subscribe_to_Single_Wildcard_Topics();
+                await Subscribe_to_Multi_Wildcard_Topics();
+
+                Console.WriteLine();
+                Console.WriteLine("End message throughput test");
+            }
+            catch (Exception ex)
+            {
+                ConsoleWriteLineError(ex.Message);
+            }
+            finally
+            {
+                await Cleanup();
+            }
+        }
+
+        public async Task Setup()
+        {
+            new TopicGenerator().Generate(NumPublishers, NumTopicsPerPublisher, out _topicsByPublisher, out _singleWildcardTopicsByPublisher, out _multiWildcardTopicsByPublisher);
+
+            var factory = new MqttFactory();
+            _mqttServer = factory.CreateMqttServer();
+            var serverOptions = new MqttServerOptionsBuilder().Build();
+            await _mqttServer.StartAsync(serverOptions);
+
+            Console.WriteLine();
+            Console.WriteLine("Begin connect " + NumPublishers + " publisher(s)...");
+
+            var stopWatch = new System.Diagnostics.Stopwatch();
+            stopWatch.Start();
+            _mqttPublisherClientsByPublisherName = new Dictionary<string, IMqttClient>();
+            foreach (var pt in _topicsByPublisher)
+            {
+                var publisherName = pt.Key;
+                var mqttClient = factory.CreateMqttClient();
+                var publisherOptions = new MqttClientOptionsBuilder()
+                    .WithTcpServer("localhost")
+                    .WithClientId(publisherName)
+                    .Build();
+                await mqttClient.ConnectAsync(publisherOptions);
+                _mqttPublisherClientsByPublisherName.Add(publisherName, mqttClient);
+            }
+            stopWatch.Stop();
+
+            Console.Write(string.Format("{0} publisher(s) connected in {1:0.000} seconds, ", NumPublishers, stopWatch.ElapsedMilliseconds / 1000.0));
+            Console.WriteLine(string.Format("connections per second: {0:0.000}", NumPublishers / (stopWatch.ElapsedMilliseconds / 1000.0)));
+
+            _mqttSubscriberClients = new List<IMqttClient>();
+            for (var i = 0; i < NumSubscribers; ++i)
+            {
+                var mqttClient = factory.CreateMqttClient();
+                var subsriberOptions = new MqttClientOptionsBuilder()
+                    .WithTcpServer("localhost")
+                    .WithClientId("sub" + i)
+                    .Build();
+                await mqttClient.ConnectAsync(subsriberOptions);
+                mqttClient.ApplicationMessageReceivedHandler = new Client.Receiving.MqttApplicationMessageReceivedHandlerDelegate(r =>
+                {
+                    // count messages and signal cancellation when expected message count is reached
+                    ++_messagesReceivedCount;
+                    if (_messagesReceivedCount == _messagesExpectedCount)
+                    {
+                        _cancellationTokenSource.Cancel();
+                    }
+                });
+                _mqttSubscriberClients.Add(mqttClient);
+            }
+        }
+
+        public async Task Cleanup()
+        {
+            foreach (var mqttClient in _mqttSubscriberClients)
+            {
+                await mqttClient.DisconnectAsync();
+                mqttClient.Dispose();
+            }
+
+            foreach (var pub in _mqttPublisherClientsByPublisherName)
+            {
+                var mqttClient = pub.Value;
+                await mqttClient.DisconnectAsync();
+                mqttClient.Dispose();
+            }
+
+            await _mqttServer.StopAsync();
+            _mqttServer.Dispose();
+        }
+
+
+        /// <summary>
+        /// Measure no-wildcard topic subscription message exchange performance
+        /// </summary>
+        public Task Subscribe_to_No_Wildcard_Topics()
+        {
+            return ProcessMessages(_topicsByPublisher, "no wildcards");
+        }
+
+        /// <summary>
+        /// Measure single-wildcard topic subscription message exchange performance
+        /// </summary>
+        public Task Subscribe_to_Single_Wildcard_Topics()
+        {
+            return ProcessMessages(_singleWildcardTopicsByPublisher, "single wildcard");
+        }
+
+        /// <summary>
+        /// Measure multi-wildcard topic subscription message exchange performance
+        /// </summary>
+        public Task Subscribe_to_Multi_Wildcard_Topics()
+        {
+            return ProcessMessages(_multiWildcardTopicsByPublisher, "multi wildcard");
+        }
+
+
+        /// <summary>
+        ///  Subcribe to all topics, then run message exchange
+        /// </summary>
+        public async Task ProcessMessages(Dictionary<string, List<string>> topicsByPublisher, string topicTypeDescription)
+        {
+            var numTopics = CountTopics(topicsByPublisher);
+
+            Console.WriteLine();
+            Console.Write(string.Format("Subscribing to {0} topics ", numTopics));
+            ConsoleWriteInfo(string.Format("({0})", topicTypeDescription));
+            Console.WriteLine(string.Format(" for {0} subscriber(s)...", NumSubscribers));
+
+            var stopWatch = new System.Diagnostics.Stopwatch();
+            stopWatch.Start();
+
+            // each subscriber subscribes to all topics, one call per topic
+            foreach (var subscriber in _mqttSubscriberClients)
+            {
+                foreach (var tp in topicsByPublisher)
+                {
+                    var topics = tp.Value;
+                    foreach (var topic in topics)
+                    {
+                        var topicFilter = new MqttTopicFilter() { Topic = topic };
+                        await subscriber.SubscribeAsync(topicFilter).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            stopWatch.Stop();
+
+            Console.Write(string.Format("{0} subscriber(s) subscribed in {1:0.000} seconds, ", NumSubscribers, stopWatch.ElapsedMilliseconds / 1000.0));
+            Console.WriteLine(string.Format("subscribe calls per second: {0:0.000}", numTopics / (stopWatch.ElapsedMilliseconds / 1000.0)));
+
+            await PublishAllAsync();
+
+            Console.WriteLine(string.Format("Unsubscribing {0} topics ({1}) for {2} subscriber(s)...", numTopics, topicTypeDescription, NumSubscribers));
+
+            stopWatch.Restart();
+
+            // unsubscribe to all topics, one call per topic
+            foreach (var subscriber in _mqttSubscriberClients)
+            {
+                foreach (var tp in topicsByPublisher)
+                {
+                    var topics = tp.Value;
+                    foreach (var topic in topics)
+                    {
+                        var topicFilter = new MqttTopicFilter() { Topic = topic };
+
+                        Client.Unsubscribing.MqttClientUnsubscribeOptions options =
+                            new Client.Unsubscribing.MqttClientUnsubscribeOptionsBuilder()
+                            .WithTopicFilter(topicFilter)
+                            .Build();
+                        await subscriber.UnsubscribeAsync(options).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            stopWatch.Stop();
+
+            Console.Write(string.Format("{0} subscriber(s) unsubscribed in {1:0.000} seconds, ", NumSubscribers, stopWatch.ElapsedMilliseconds / 1000.0));
+            Console.WriteLine(string.Format("unsubscribe calls per second: {0:0.000}", numTopics / (stopWatch.ElapsedMilliseconds / 1000.0)));
+        }
+
+
+        /// <summary>
+        /// Publish messages in batches of NumPublishCallsPerBatch, wait for messages sent to subscriber
+        /// </summary>
+        async Task PublishAllAsync()
+        {
+            Console.WriteLine("Begin message exchange...");
+
+            int publisherIndexCounter = 0;       // index to loop around all publishers to publish
+            int topicIndexCounter = 0;           // index to loop around all topics to publish
+            int totalNumMessagesReceived = 0;
+
+            var publisherNames = _topicsByPublisher.Keys.ToList();
+
+            // There should be one message received per publish
+            _messagesExpectedCount = NumPublishCallsPerBatch;
+
+            var stopWatch = new System.Diagnostics.Stopwatch();
+            stopWatch.Start();
+
+            // Loop for a while and exchange messages
+
+            while (stopWatch.ElapsedMilliseconds < 10000)
+            {
+                _messagesReceivedCount = 0;
+
+                _cancellationTokenSource = new CancellationTokenSource();
+
+                for (var publishCallCount = 0; publishCallCount < NumPublishCallsPerBatch; ++publishCallCount)
+                {
+                    // pick a publisher
+                    var publisherName = publisherNames[publisherIndexCounter % publisherNames.Count];
+                    var publisherTopics = _topicsByPublisher[publisherName];
+                    // pick a publisher topic
+                    var topic = publisherTopics[topicIndexCounter % publisherTopics.Count];
+                    var message = new MqttApplicationMessageBuilder()
+                        .WithTopic(topic)
+                        .Build();
+                    await _mqttPublisherClientsByPublisherName[publisherName].PublishAsync(message).ConfigureAwait(false);
+                    ++topicIndexCounter;
+                    ++publisherIndexCounter;
+                }
+
+                // Wait for at least one message per publish to be received by subscriber (in the subscriber's application message handler),
+                // then loop around to send another batch
+                try
+                {
+                    await Task.Delay(30000, _cancellationTokenSource.Token).ConfigureAwait(false);
+                }
+                catch
+                {
+
+                }
+
+                _cancellationTokenSource.Dispose();
+
+                if (_messagesReceivedCount < _messagesExpectedCount)
+                {
+                    ConsoleWriteLineError(string.Format("Messages Received Count mismatch, expected {0}, received {1}", _messagesExpectedCount, _messagesReceivedCount));
+                    return;
+                }
+
+                totalNumMessagesReceived += _messagesReceivedCount;
+            }
+
+            stopWatch.Stop();
+
+            System.Console.Write(string.Format("{0} messages published and received in {1:0.000} seconds, ", totalNumMessagesReceived, stopWatch.ElapsedMilliseconds / 1000.0));
+            ConsoleWriteLineSuccess(string.Format("messages per second: {0:0.000}", totalNumMessagesReceived / (stopWatch.ElapsedMilliseconds / 1000.0)));
+        }
+
+        int CountTopics(Dictionary<string, List<string>> topicsByPublisher)
+        {
+            var count = 0;
+            foreach (var tp in topicsByPublisher)
+            {
+                count += tp.Value.Count;
+            }
+            return count;
+        }
+
+        void ConsoleWriteLineError(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(message);
+            Console.ResetColor();
+        }
+
+        void ConsoleWriteLineSuccess(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine(message);
+            Console.ResetColor();
+        }
+
+        void ConsoleWriteInfo(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.Write(message);
+            Console.ResetColor();
+        }
+
+    }
+}

--- a/Tests/MQTTnet.TestApp.NetCore/MessageThroughputTest.cs
+++ b/Tests/MQTTnet.TestApp.NetCore/MessageThroughputTest.cs
@@ -303,7 +303,7 @@ namespace MQTTnet.TestApp.NetCore
             stopWatch.Stop();
 
             System.Console.Write(string.Format("{0} messages published and received in {1:0.000} seconds, ", totalNumMessagesReceived, stopWatch.ElapsedMilliseconds / 1000.0));
-            ConsoleWriteLineSuccess(string.Format("messages per second: {0:0.000}", totalNumMessagesReceived / (stopWatch.ElapsedMilliseconds / 1000.0)));
+            ConsoleWriteLineSuccess(string.Format("messages per second: {0}", (int)(totalNumMessagesReceived / (stopWatch.ElapsedMilliseconds / 1000.0))));
         }
 
         int CountTopics(Dictionary<string, List<string>> topicsByPublisher)

--- a/Tests/MQTTnet.TestApp.NetCore/Program.cs
+++ b/Tests/MQTTnet.TestApp.NetCore/Program.cs
@@ -1,4 +1,4 @@
-﻿using MQTTnet.Client.Options;
+using MQTTnet.Client.Options;
 using MQTTnet.Diagnostics;
 using MQTTnet.Server;
 using Newtonsoft.Json;
@@ -33,6 +33,7 @@ namespace MQTTnet.TestApp.NetCore
             Console.WriteLine("b = Start QoS 1 benchmark");
             Console.WriteLine("c = Start QoS 0 benchmark");
             Console.WriteLine("d = Start server with logging");
+            Console.WriteLine("e = Start Message Throughput Test");
 
             var pressedKey = Console.ReadKey(true);
             if (pressedKey.KeyChar == '1')
@@ -88,6 +89,10 @@ namespace MQTTnet.TestApp.NetCore
             else if (pressedKey.KeyChar == 'd')
             {
                 Task.Run(ServerTest.RunEmptyServerWithLogging);
+            }
+            else if (pressedKey.KeyChar == 'e')
+            {
+                Task.Run(new MessageThroughputTest().Run);
             }
 
             Thread.Sleep(Timeout.Infinite);

--- a/Tests/MQTTnet.TestApp.NetCore/TopicGenerator.cs
+++ b/Tests/MQTTnet.TestApp.NetCore/TopicGenerator.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MQTTnet.TestApp.NetCore
+{
+    public class TopicGenerator
+    {
+        public void Generate(
+           int numPublishers, int numTopicsPerPublisher,
+           out Dictionary<string, List<string>> topicsByPublisher,
+           out Dictionary<string, List<string>> singleWildcardTopicsByPublisher,
+           out Dictionary<string, List<string>> multiWildcardTopicsByPublisher
+           )
+        {
+            topicsByPublisher = new Dictionary<string, List<string>>();
+            singleWildcardTopicsByPublisher = new Dictionary<string, List<string>>();
+            multiWildcardTopicsByPublisher = new Dictionary<string, List<string>>();
+
+            // Find some reasonable distribution across three topic levels
+            var topicsPerLevel = (int)Math.Pow(numTopicsPerPublisher, (1.0 / 3.0));
+
+            int numLevel1Topics = topicsPerLevel;
+            if (numLevel1Topics <= 0)
+            {
+                numLevel1Topics = 1;
+            }
+            int numLevel2Topics = topicsPerLevel;
+            if (numLevel2Topics <= 0)
+            {
+                numLevel2Topics = 1;
+            }
+            var maxNumLevel3Topics = 1 + (int)((double)numTopicsPerPublisher / numLevel1Topics / numLevel2Topics);
+            if (maxNumLevel3Topics <= 0)
+            {
+                maxNumLevel3Topics = 1;
+            }
+            for (var p = 0; p < numPublishers; ++p)
+            {
+                int publisherTopicCount = 0;
+
+                var publisherName = "pub" + p;
+                for (var l1 = 0; l1 < numLevel1Topics; ++l1)
+                {
+                    for (var l2 = 0; l2 < numLevel2Topics; ++l2)
+                    {
+                        for (var l3 = 0; l3 < maxNumLevel3Topics; ++l3)
+                        {
+                            if (publisherTopicCount >= numTopicsPerPublisher)
+                                break;
+
+                            var topic = string.Format("{0}/building{1}/level{2}/sensor{3}", publisherName, l1 + 1, l2 + 1, l3 + 1);
+                            AddPublisherTopic(publisherName, topic, topicsByPublisher);
+
+                            if (l2 == 0)
+                            {
+                                var singleWildcardTopic = string.Format("{0}/building{1}/+/sensor{2}", publisherName, l1 + 1, l3 + 1);
+                                AddPublisherTopic(publisherName, singleWildcardTopic, singleWildcardTopicsByPublisher);
+                                if (l1 == 0)
+                                {
+                                    var multiWildcardTopic = string.Format("{0}/+/level{1}/+", publisherName, l3 + 1);
+                                    AddPublisherTopic(publisherName, multiWildcardTopic, multiWildcardTopicsByPublisher);
+                                }
+                            }
+
+                            ++publisherTopicCount;
+                        }
+                    }
+                }
+            }
+        }
+
+        void AddPublisherTopic(string publisherName, string topic, Dictionary<string, List<string>> topicsByPublisher)
+        {
+            List<string> topicList;
+            if (!topicsByPublisher.TryGetValue(publisherName, out topicList))
+            {
+                topicList = new List<string>();
+                topicsByPublisher.Add(publisherName, topicList);
+            }
+            topicList.Add(topic);
+        }
+    }
+}


### PR DESCRIPTION
I'd like to look at improving performance for the somewhat typical use case where there are many publishers and topics but only few subscribers. Currently, the server slows down quite a bit as the number of publishers and topics increase.

This pull request merely adds a "Message Throughput Test" to the NetCore App as the basis for comparison. The test creates 1 subscriber client and 5000 publishers with 10 topics each (50000 topics total), generates subscriptions for no-wildcard topics, single-wildcard topics and multi-wildcard topics and measures the time it takes to publish and receive messages. The number of publishers and topics can be adjusted to suit but require a rebuild with the constants changed. This could be a bit more flexible in the future.

In the coming days I'd also like to propose some performance improvements if that is of interest? For the "5000 publishers / 50000 topics" case the achievable speed-up seems to be about 50x, and for "100 publishers / 1000 topics" it is still 3x or so (but then the server is already relatively fast). @chkr1011, I'm aware that there is other work going on, but maybe it would be helpful to add the proposal as a pull request now even if any potential merge occurs much later?

Here is some test output for the added test.

![mqttnet-msg-throughput-test](https://user-images.githubusercontent.com/47704763/140006257-4c38b24f-5006-47b0-a373-09166629ce17.png)

