### PR TITLE
Improve exception message when handling connection errors

### DIFF
--- a/Source/MQTTnet/Exceptions/MqttCommunicationTimedOutException.cs
+++ b/Source/MQTTnet/Exceptions/MqttCommunicationTimedOutException.cs
@@ -8,7 +8,7 @@ namespace MQTTnet.Exceptions
         {
         }
 
-        public MqttCommunicationTimedOutException(Exception innerException) : base(innerException)
+        public MqttCommunicationTimedOutException(Exception innerException) : base("The operation has timed out.", innerException)
         {
         }
     }


### PR DESCRIPTION
Right now, when the MQTT connection times out, the exception message is pretty confusing, as the message from the InnerException (`OperationCanceledException`) is used:
```
MQTTnet.Exceptions.MqttCommunicationTimedOutException: The operation was canceled.
 ---> System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
[...]
```
This PR changes the message from `The operation was canceled.` to `The operation has timed out.`, which seems more appropriate for this kind of exception.