### PR TITLE
Fix statistics tracking for bytes sent and received in MqttChannelAdapter

### DIFF
--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -162,7 +162,7 @@ public sealed class MqttChannelAdapter : Disposable, IMqttChannelAdapter
                 await localPacketInspector.EndReceivePacket().ConfigureAwait(false);
             }
 
-            Interlocked.Add(ref _statistics._bytesSent, receivedPacket.TotalLength);
+            Interlocked.Add(ref _statistics._bytesReceived, receivedPacket.TotalLength);
 
             if (PacketFormatterAdapter.ProtocolVersion == MqttProtocolVersion.Unknown)
             {
@@ -235,7 +235,7 @@ public sealed class MqttChannelAdapter : Disposable, IMqttChannelAdapter
                     await _channel.WriteAsync(packetBuffer.Payload, true, cancellationToken).ConfigureAwait(false);
                 }
 
-                Interlocked.Add(ref _statistics._bytesReceived, packetBuffer.Length);
+                Interlocked.Add(ref _statistics._bytesSent, packetBuffer.Length);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
The `BytesSent` and `BytesReceived` counters in `MqttChannelAdapter` are swapped — `ReceivePacketAsync` increments `_bytesSent` and `SendPacketAsync` increments `_bytesReceived`.