### PR TITLE
Support for client specific messages

### DIFF
--- a/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
@@ -189,6 +189,11 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
                         continue;
                     }
 
+                    if (applicationMessage.DestinationClientId != null && applicationMessage.DestinationClientId != session.Id)
+                    {
+                        continue;
+                    }
+
                     if (await _eventContainer.ShouldSkipEnqueue(senderId, session.Id, applicationMessage))
                     {
                         continue;

--- a/Source/MQTTnet/MqttApplicationMessage.cs
+++ b/Source/MQTTnet/MqttApplicationMessage.cs
@@ -140,4 +140,10 @@ public sealed class MqttApplicationMessage
     ///     Hint: MQTT 5 feature only.
     /// </summary>
     public List<MqttUserProperty> UserProperties { get; set; }
+
+    /// <summary>
+    ///     Gets or sets a destination client id. If this value is set, only the specified client is eligible to receive the message.
+    ///     The client must be subscribed to an applicable topic to receive this message.
+    /// </summary>
+    public string DestinationClientId { get; set; }
 }


### PR DESCRIPTION
This change adds DestinationClientId onto MqttApplicationMessages. If this value is non-null, only that specific subscriber will receive the message. This makes it possible to have a single topic shared by multiple clients.